### PR TITLE
feat: email template library + /templates page + Browse picker (HIR-75)

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@
 
 # Move the needle TO-DO list:
 
-- [ ] Templates for popular email needs i.e "onboarding for SaaS"
+- [x] Templates for popular email needs i.e "onboarding for SaaS" — see `/templates`
 - [ ] Integration with GHL / N8N
 
 # Content TO-DO list:

--- a/src/app/(frontend)/dashboard/campaigns/new/page.tsx
+++ b/src/app/(frontend)/dashboard/campaigns/new/page.tsx
@@ -1,0 +1,146 @@
+'use client'
+
+import { Suspense, useCallback, useEffect, useState } from 'react'
+import { useSearchParams } from 'next/navigation'
+import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
+import { Label } from '@/components/ui/label'
+import { Textarea } from '@/components/ui/textarea'
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog'
+import { TemplatePicker } from '@/components/TemplatePicker'
+import {
+  getTemplateById,
+  type EmailTemplate,
+} from '@/lib/templates/catalog'
+
+function NewCampaignPageInner() {
+  const searchParams = useSearchParams()
+  const [name, setName] = useState('')
+  const [subject, setSubject] = useState('')
+  const [body, setBody] = useState('')
+  const [variables, setVariables] = useState<string[]>([])
+  const [pickerOpen, setPickerOpen] = useState(false)
+
+  const applyTemplate = useCallback(
+    (template: EmailTemplate) => {
+      setSubject(template.subject)
+      setBody(template.body)
+      setVariables(template.variables)
+      setName((current) => current || template.name)
+    },
+    [],
+  )
+
+  useEffect(() => {
+    const id = searchParams.get('templateId')
+    if (!id) return
+    const template = getTemplateById(id)
+    if (template) applyTemplate(template)
+  }, [searchParams, applyTemplate])
+
+  return (
+    <div className="p-8">
+      <div className="max-w-3xl mx-auto">
+        <header className="mb-6 flex items-start justify-between gap-4">
+          <div>
+            <h1 className="text-2xl font-bold mb-1">New sequence</h1>
+            <p className="text-muted-foreground text-sm">
+              Single-step email sequence. Use{' '}
+              <code className="text-xs px-1 py-0.5 bg-muted rounded">{`{{first_name}}`}</code>{' '}
+              and other variables that get replaced per recipient.
+            </p>
+          </div>
+          <Button
+            type="button"
+            variant="outline"
+            onClick={() => setPickerOpen(true)}
+          >
+            Browse templates
+          </Button>
+        </header>
+
+        <form className="space-y-4">
+          <div>
+            <Label htmlFor="campaign-name">Name</Label>
+            <Input
+              id="campaign-name"
+              value={name}
+              onChange={(e) => setName(e.target.value)}
+              placeholder="e.g. SaaS onboarding — May launch"
+            />
+          </div>
+
+          <div>
+            <Label htmlFor="campaign-subject">Subject</Label>
+            <Input
+              id="campaign-subject"
+              value={subject}
+              onChange={(e) => setSubject(e.target.value)}
+              placeholder="Welcome to {{product_name}}, {{first_name}}"
+            />
+          </div>
+
+          <div>
+            <Label htmlFor="campaign-body">Body</Label>
+            <Textarea
+              id="campaign-body"
+              value={body}
+              onChange={(e) => setBody(e.target.value)}
+              rows={14}
+              placeholder="Hi {{first_name}}, ..."
+            />
+          </div>
+
+          {variables.length > 0 && (
+            <div>
+              <Label>Variables in this template</Label>
+              <div className="flex flex-wrap gap-2 mt-1">
+                {variables.map((v) => (
+                  <code
+                    key={v}
+                    className="text-xs px-2 py-1 bg-muted rounded"
+                  >
+                    {`{{${v}}}`}
+                  </code>
+                ))}
+              </div>
+            </div>
+          )}
+        </form>
+
+        <Dialog open={pickerOpen} onOpenChange={setPickerOpen}>
+          <DialogContent className="max-w-5xl max-h-[85vh] overflow-y-auto">
+            <DialogHeader>
+              <DialogTitle>Browse templates</DialogTitle>
+              <DialogDescription>
+                Pick one to prefill subject and body. You can edit after
+                applying.
+              </DialogDescription>
+            </DialogHeader>
+            <TemplatePicker
+              useButtonLabel="Use this template"
+              onUseTemplate={(template) => {
+                applyTemplate(template)
+                setPickerOpen(false)
+              }}
+            />
+          </DialogContent>
+        </Dialog>
+      </div>
+    </div>
+  )
+}
+
+export default function NewCampaignPage() {
+  return (
+    <Suspense fallback={null}>
+      <NewCampaignPageInner />
+    </Suspense>
+  )
+}

--- a/src/app/(frontend)/templates/page.tsx
+++ b/src/app/(frontend)/templates/page.tsx
@@ -1,0 +1,29 @@
+'use client'
+
+import { useRouter } from 'next/navigation'
+import { TemplatePicker } from '@/components/TemplatePicker'
+import type { EmailTemplate } from '@/lib/templates/catalog'
+
+export default function TemplatesPage() {
+  const router = useRouter()
+
+  const handleUse = (template: EmailTemplate) => {
+    router.push(`/dashboard/campaigns/new?templateId=${template.id}`)
+  }
+
+  return (
+    <div className="p-8">
+      <div className="max-w-7xl mx-auto">
+        <header className="mb-6">
+          <h1 className="text-2xl font-bold mb-2">Email templates</h1>
+          <p className="text-muted-foreground">
+            Pick a starting point for your next sequence. Each template uses{' '}
+            <code className="text-xs px-1 py-0.5 bg-muted rounded">{`{{variable}}`}</code>{' '}
+            placeholders that get replaced per-recipient.
+          </p>
+        </header>
+        <TemplatePicker onUseTemplate={handleUse} />
+      </div>
+    </div>
+  )
+}

--- a/src/components/TemplatePicker/index.tsx
+++ b/src/components/TemplatePicker/index.tsx
@@ -1,0 +1,80 @@
+'use client'
+
+import { useState } from 'react'
+import { Button } from '@/components/ui/button'
+import {
+  TEMPLATES,
+  type EmailTemplate,
+  type TemplateCategory,
+} from '@/lib/templates/catalog'
+
+const CATEGORY_LABELS: Record<TemplateCategory, string> = {
+  saas: 'SaaS',
+  agency: 'Agency',
+  recruiting: 'Recruiting',
+  b2b: 'B2B',
+  founder: 'Founder',
+  re_engagement: 'Re-engagement',
+}
+
+type TemplatePickerProps = {
+  onUseTemplate: (template: EmailTemplate) => void
+  useButtonLabel?: string
+}
+
+export function TemplatePicker({
+  onUseTemplate,
+  useButtonLabel = 'Use this template',
+}: TemplatePickerProps) {
+  const [previewId, setPreviewId] = useState<string | null>(null)
+  const preview = previewId ? TEMPLATES.find((t) => t.id === previewId) : null
+
+  return (
+    <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
+      {TEMPLATES.map((template) => (
+        <article
+          key={template.id}
+          className="border border-border rounded-lg p-4 flex flex-col bg-card"
+          data-testid={`template-card-${template.id}`}
+        >
+          <div className="flex items-start justify-between mb-2 gap-2">
+            <h3 className="font-semibold text-base">{template.name}</h3>
+            <span className="text-xs px-2 py-1 rounded bg-secondary text-secondary-foreground whitespace-nowrap">
+              {CATEGORY_LABELS[template.category]}
+            </span>
+          </div>
+          <p className="text-sm text-muted-foreground mb-3">
+            {template.description}
+          </p>
+          <p className="text-xs text-muted-foreground mb-4">
+            <strong>Subject:</strong> {template.subject}
+          </p>
+          <div className="mt-auto flex gap-2">
+            <Button
+              size="sm"
+              variant="outline"
+              type="button"
+              onClick={() =>
+                setPreviewId(previewId === template.id ? null : template.id)
+              }
+            >
+              {previewId === template.id ? 'Hide' : 'Preview'}
+            </Button>
+            <Button
+              size="sm"
+              type="button"
+              onClick={() => onUseTemplate(template)}
+            >
+              {useButtonLabel}
+            </Button>
+          </div>
+          {preview && preview.id === template.id && (
+            <pre className="mt-3 p-3 bg-muted rounded text-xs whitespace-pre-wrap font-mono">
+              {preview.body}
+            </pre>
+          )}
+        </article>
+      ))}
+    </div>
+  )
+}

--- a/src/lib/templates/catalog.ts
+++ b/src/lib/templates/catalog.ts
@@ -1,0 +1,198 @@
+/**
+ * Email template catalog.
+ *
+ * Templates use the same `{{variable}}` placeholder syntax as the campaigns
+ * API (see src/app/api/campaigns/route.ts). The `variables` array on each
+ * template lists every placeholder name found in `subject` or `body`.
+ *
+ * To add a template: append an entry below and ensure every `{{name}}` in
+ * subject/body is listed in `variables`. The catalog test enforces this.
+ */
+
+export type TemplateCategory =
+  | 'saas'
+  | 'agency'
+  | 'recruiting'
+  | 'b2b'
+  | 'founder'
+  | 're_engagement'
+
+export type EmailTemplate = {
+  id: string
+  name: string
+  category: TemplateCategory
+  description: string
+  subject: string
+  body: string
+  variables: string[]
+}
+
+export const TEMPLATES: EmailTemplate[] = [
+  {
+    id: 'saas_onboarding',
+    name: 'SaaS Onboarding',
+    category: 'saas',
+    description:
+      'Warm welcome to a new signup that nudges them to the first activation step.',
+    subject: 'Welcome to {{product_name}}, {{first_name}}',
+    body: `Hi {{first_name}},
+
+Thanks for signing up for {{product_name}}. Most teams get value in the first 10 minutes by doing one thing: {{first_action}}.
+
+Want me to walk you through it on a quick call, or would a short loom be more useful?
+
+Either way, reply here and I'll get it to you today.
+
+— {{sender_name}}`,
+    variables: ['first_name', 'product_name', 'first_action', 'sender_name'],
+  },
+  {
+    id: 'agency_outreach',
+    name: 'Agency Outreach',
+    category: 'agency',
+    description:
+      'Cold outreach from an agency offering a specific service to a target prospect.',
+    subject: 'Helping {{company}} with {{service_area}}',
+    body: `Hi {{first_name}},
+
+I run {{agency_name}} and we help {{target_segment}} like {{company}} with {{service_area}}. Recently we helped {{case_study_company}} {{case_study_outcome}}.
+
+If it's worth 15 minutes to see whether we could do something similar for {{company}}, here's my calendar: {{calendar_link}}.
+
+If not, no worries — appreciate you reading.
+
+— {{sender_name}}`,
+    variables: [
+      'first_name',
+      'company',
+      'service_area',
+      'agency_name',
+      'target_segment',
+      'case_study_company',
+      'case_study_outcome',
+      'calendar_link',
+      'sender_name',
+    ],
+  },
+  {
+    id: 'recruiter_outbound',
+    name: 'Recruiter Outbound',
+    category: 'recruiting',
+    description:
+      'Outbound from a recruiter or hiring manager to a passive candidate.',
+    subject: '{{role_title}} role at {{company}} — open to a chat?',
+    body: `Hi {{first_name}},
+
+I'm hiring a {{role_title}} at {{company}} and your background in {{candidate_skill}} stood out — especially your work at {{candidate_current_company}}.
+
+Quick context: comp is {{comp_range}}, the team is {{team_size}}, and we're working on {{problem_focus}}.
+
+Worth a 20-minute call this week to see if it's a fit? If now's not the right moment, I'm happy to keep in touch.
+
+— {{sender_name}}`,
+    variables: [
+      'first_name',
+      'role_title',
+      'company',
+      'candidate_skill',
+      'candidate_current_company',
+      'comp_range',
+      'team_size',
+      'problem_focus',
+      'sender_name',
+    ],
+  },
+  {
+    id: 'b2b_warm_intro',
+    name: 'B2B Warm Intro',
+    category: 'b2b',
+    description:
+      'Mutual-connection intro to a prospect after a referral or shared thread.',
+    subject: '{{mutual_contact}} suggested I reach out',
+    body: `Hi {{first_name}},
+
+{{mutual_contact}} mentioned you're thinking about {{problem_area}} at {{company}} and suggested we connect. We help teams ship {{solution_outcome}} without {{usual_friction}}.
+
+Happy to send a 2-minute walkthrough video, or grab 15 minutes if that's easier: {{calendar_link}}.
+
+— {{sender_name}}`,
+    variables: [
+      'first_name',
+      'mutual_contact',
+      'problem_area',
+      'company',
+      'solution_outcome',
+      'usual_friction',
+      'calendar_link',
+      'sender_name',
+    ],
+  },
+  {
+    id: 'founder_to_founder',
+    name: 'Founder to Founder',
+    category: 'founder',
+    description:
+      'Personal note from a founder to a peer founder — peer tone, low ask.',
+    subject: 'Quick one, {{first_name}}',
+    body: `Hi {{first_name}},
+
+Founder at {{my_company}} here. Saw what you're building at {{company}} and the {{specific_observation}} caught my eye — we ran into the exact same wall last year.
+
+Would you be open to a 20-minute swap on {{topic}}? Happy to share what worked (and what burned us) in exchange for hearing how you're thinking about it.
+
+No agenda beyond that.
+
+— {{sender_name}}`,
+    variables: [
+      'first_name',
+      'my_company',
+      'company',
+      'specific_observation',
+      'topic',
+      'sender_name',
+    ],
+  },
+  {
+    id: 're_engagement_silent_3day',
+    name: 'Re-engagement (3-Day Silent)',
+    category: 're_engagement',
+    description:
+      'Follow-up to a warm prospect who replied with interest, then went quiet for ~3 days.',
+    subject: 'Re: {{previous_subject}}',
+    body: `Hi {{first_name}},
+
+Circling back on the thread below — last we spoke you mentioned {{stated_interest}} and I sent over {{thing_sent}}.
+
+A few quick options to keep this moving:
+1. 15-minute call this week: {{calendar_link}}
+2. Async — reply with your top question and I'll record a Loom
+3. Park it and I'll follow up in {{followup_window}}
+
+Whatever's easiest.
+
+— {{sender_name}}`,
+    variables: [
+      'first_name',
+      'previous_subject',
+      'stated_interest',
+      'thing_sent',
+      'calendar_link',
+      'followup_window',
+      'sender_name',
+    ],
+  },
+]
+
+const PLACEHOLDER_REGEX = /\{\{\s*([a-zA-Z_][a-zA-Z0-9_]*)\s*\}\}/g
+
+export function extractPlaceholders(text: string): string[] {
+  const found = new Set<string>()
+  for (const match of text.matchAll(PLACEHOLDER_REGEX)) {
+    found.add(match[1])
+  }
+  return Array.from(found)
+}
+
+export function getTemplateById(id: string): EmailTemplate | undefined {
+  return TEMPLATES.find((t) => t.id === id)
+}

--- a/tests/int/templates.int.spec.ts
+++ b/tests/int/templates.int.spec.ts
@@ -1,0 +1,101 @@
+import { describe, expect, it } from 'vitest'
+import {
+  TEMPLATES,
+  extractPlaceholders,
+  getTemplateById,
+  type EmailTemplate,
+} from '@/lib/templates/catalog'
+
+const REQUIRED_TEMPLATE_IDS = [
+  'saas_onboarding',
+  'agency_outreach',
+  'recruiter_outbound',
+  'b2b_warm_intro',
+  'founder_to_founder',
+  're_engagement_silent_3day',
+] as const
+
+describe('email template catalog', () => {
+  it('parses and exports a non-empty template list', () => {
+    expect(Array.isArray(TEMPLATES)).toBe(true)
+    expect(TEMPLATES.length).toBeGreaterThan(0)
+  })
+
+  it('seeds every required template from HIR-75', () => {
+    const ids = TEMPLATES.map((t) => t.id)
+    for (const required of REQUIRED_TEMPLATE_IDS) {
+      expect(ids).toContain(required)
+    }
+  })
+
+  it('uses unique template ids', () => {
+    const ids = TEMPLATES.map((t) => t.id)
+    expect(new Set(ids).size).toBe(ids.length)
+  })
+
+  it('declares variables that exactly match placeholders in subject + body', () => {
+    for (const template of TEMPLATES) {
+      const placeholdersInSubject = extractPlaceholders(template.subject)
+      const placeholdersInBody = extractPlaceholders(template.body)
+      const allPlaceholders = new Set([
+        ...placeholdersInSubject,
+        ...placeholdersInBody,
+      ])
+      const declared = new Set(template.variables)
+
+      // No undeclared placeholder in the template text.
+      for (const placeholder of allPlaceholders) {
+        expect(
+          declared.has(placeholder),
+          `template "${template.id}" uses {{${placeholder}}} but does not declare it in variables`,
+        ).toBe(true)
+      }
+
+      // No declared variable that is unused in the text.
+      for (const declaredVar of declared) {
+        expect(
+          allPlaceholders.has(declaredVar),
+          `template "${template.id}" declares variable "${declaredVar}" but it is not used in subject or body`,
+        ).toBe(true)
+      }
+    }
+  })
+
+  it('has non-empty fields for every template', () => {
+    for (const template of TEMPLATES) {
+      const t: EmailTemplate = template
+      expect(t.id.length).toBeGreaterThan(0)
+      expect(t.name.length).toBeGreaterThan(0)
+      expect(t.category.length).toBeGreaterThan(0)
+      expect(t.subject.length).toBeGreaterThan(0)
+      expect(t.body.length).toBeGreaterThan(0)
+      expect(Array.isArray(t.variables)).toBe(true)
+    }
+  })
+
+  it('getTemplateById returns the matching template or undefined', () => {
+    expect(getTemplateById('saas_onboarding')?.id).toBe('saas_onboarding')
+    expect(getTemplateById('does-not-exist')).toBeUndefined()
+  })
+})
+
+describe('extractPlaceholders', () => {
+  it('returns each unique placeholder name once', () => {
+    const text = 'Hi {{first_name}}, your {{first_name}} order at {{company}}.'
+    expect(extractPlaceholders(text).sort()).toEqual(['company', 'first_name'])
+  })
+
+  it('handles whitespace inside braces', () => {
+    expect(extractPlaceholders('Hello {{ first_name }}!')).toEqual([
+      'first_name',
+    ])
+  })
+
+  it('returns an empty array when there are no placeholders', () => {
+    expect(extractPlaceholders('plain text with no variables')).toEqual([])
+  })
+
+  it('ignores single-brace tokens', () => {
+    expect(extractPlaceholders('hello {first_name}')).toEqual([])
+  })
+})


### PR DESCRIPTION
## Summary

Adds the first 'move the needle' README TODO: a starter email template library.

- `src/lib/templates/catalog.ts` — 6 seeded templates (`saas_onboarding`, `agency_outreach`, `recruiter_outbound`, `b2b_warm_intro`, `founder_to_founder`, `re_engagement_silent_3day`) using the existing `{{variable}}` placeholder syntax from the campaigns API (`src/app/api/campaigns/route.ts`).
- `/templates` (Next.js app router) — grid of template cards with preview + 'Use this template' that hands off to the sequence form.
- `/dashboard/campaigns/new` — single-step sequence-creation form with a 'Browse templates' button that opens the same picker as a modal, and `?templateId=` prefill from the templates page.
- `tests/int/templates.int.spec.ts` — 10 unit tests (vitest) verifying:
  - all 6 required templates are seeded with unique IDs
  - every `{{placeholder}}` in subject/body is declared in `variables[]`
  - every declared variable is actually used in the template text
  - `extractPlaceholders` and `getTemplateById` behave correctly

## Notes for reviewers

- I went with `{{first_name}}` (existing campaigns API syntax) rather than the `{first_name}` shape mentioned in the issue body — per the engineer's note to match the existing templating system.
- Repo had no UI for sequence creation yet (only the `/api/campaigns` endpoint), so I added a minimal one at `/dashboard/campaigns/new`. That gives the modal somewhere to live without introducing a new abstraction.
- Out of scope (follow-ups): template editing UI, user-saved custom templates, AI generation.

## Test plan

- [x] `pnpm exec vitest run --config ./vitest.config.mts tests/int/templates.int.spec.ts` — 10/10 pass
- [x] `pnpm exec next lint` clean on all new files
- [x] `pnpm exec tsc --noEmit` — no new type errors introduced (pre-existing errors in `libs/db`, `src/app/api/campaigns/route.ts`, etc. are unchanged)
- [ ] Visual QA on `/templates` and `/dashboard/campaigns/new` (auth-gated, deferred to local run)

## Definition of done

- [x] PR open against `pypesdev/coldflow` main branch
- [x] All 6 templates render in `/templates` page (rendered via `TemplatePicker`)
- [x] Picker prefills sequence-creation form correctly (URL param + modal handler both call `applyTemplate`)
- [x] Catalog test green in CI
- [x] README's 'Move the needle TO-DO' templates checkbox ticked

Closes HIR-75. Parent: HIR-74.