### PR TITLE
feat: silent-reply follow-up module (HIR-76)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -35,3 +35,7 @@ GMAIL_OAUTH_REDIRECT_URI=http://localhost:3000/api/email-accounts/oauth/callback
 
 # Webhook secret for securing tracking endpoints
 GMAIL_WEBHOOK_SECRET=YOUR_WEBHOOK_SECRET_HERE
+
+# Silent-reply follow-up: days between prospect reply and the auto follow-up.
+# Pulled at runtime so we can tune in prod without a deploy.
+REPLY_FOLLOWUP_OFFSET_DAYS=3

--- a/README.md
+++ b/README.md
@@ -26,6 +26,10 @@
 - Create a single-step email sequence with basic personalization ({first_name}).
 - Send the emails (with a strict, safe sending limit).
 - See a basic dashboard showing "sent" and "replied."
+- Silent-reply follow-up: when a prospect replies asking for pricing/details
+  (or any question) and then goes silent, automatically schedule a short
+  follow-up 3 days later. The follow-up cancels itself if the prospect
+  replies again before it sends. See **Pending follow-ups** on the dashboard.
 
 
 

--- a/libs/db/drizzle/0007_rare_vector.sql
+++ b/libs/db/drizzle/0007_rare_vector.sql
@@ -1,0 +1,27 @@
+CREATE TYPE "public"."reply_followup_status" AS ENUM('scheduled', 'sent', 'cancelled');--> statement-breakpoint
+CREATE TABLE "reply_followup" (
+	"id" text PRIMARY KEY NOT NULL,
+	"sequence_id" text NOT NULL,
+	"contact_id" text NOT NULL,
+	"recipient_email" text NOT NULL,
+	"last_reply_at" timestamp NOT NULL,
+	"last_reply_excerpt" text,
+	"scheduled_send_at" timestamp NOT NULL,
+	"status" "reply_followup_status" DEFAULT 'scheduled' NOT NULL,
+	"template_id" text,
+	"sent_queue_id" text,
+	"cancel_reason" text,
+	"sent_at" timestamp,
+	"created_at" timestamp DEFAULT now() NOT NULL,
+	"updated_at" timestamp DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+ALTER TABLE "reply_followup" ADD CONSTRAINT "reply_followup_sequence_id_email_campaign_id_fk" FOREIGN KEY ("sequence_id") REFERENCES "public"."email_campaign"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "reply_followup" ADD CONSTRAINT "reply_followup_contact_id_email_queue_id_fk" FOREIGN KEY ("contact_id") REFERENCES "public"."email_queue"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "reply_followup" ADD CONSTRAINT "reply_followup_template_id_email_template_id_fk" FOREIGN KEY ("template_id") REFERENCES "public"."email_template"("id") ON DELETE set null ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "reply_followup" ADD CONSTRAINT "reply_followup_sent_queue_id_email_queue_id_fk" FOREIGN KEY ("sent_queue_id") REFERENCES "public"."email_queue"("id") ON DELETE set null ON UPDATE no action;--> statement-breakpoint
+CREATE INDEX "reply_followup_sequenceId_idx" ON "reply_followup" USING btree ("sequence_id");--> statement-breakpoint
+CREATE INDEX "reply_followup_contactId_idx" ON "reply_followup" USING btree ("contact_id");--> statement-breakpoint
+CREATE INDEX "reply_followup_status_idx" ON "reply_followup" USING btree ("status");--> statement-breakpoint
+CREATE INDEX "reply_followup_scheduledSendAt_idx" ON "reply_followup" USING btree ("scheduled_send_at");--> statement-breakpoint
+CREATE INDEX "reply_followup_status_scheduledSendAt_idx" ON "reply_followup" USING btree ("status","scheduled_send_at");

--- a/libs/db/drizzle/meta/0007_snapshot.json
+++ b/libs/db/drizzle/meta/0007_snapshot.json
@@ -1,0 +1,2108 @@
+{
+  "id": "3d42e14b-424b-4dce-97ee-376d78bb821d",
+  "prevId": "27b3d87c-e7f4-4e68-ba83-d19078e61c26",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.account": {
+      "name": "account",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "account_userId_idx": {
+          "name": "account_userId_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "account_user_id_user_id_fk": {
+          "name": "account_user_id_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agency_user": {
+      "name": "agency_user",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sub_agency_id": {
+          "name": "sub_agency_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "role": {
+          "name": "role",
+          "type": "role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'member'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "agency_user_userId_idx": {
+          "name": "agency_user_userId_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "agency_user_subAgencyId_idx": {
+          "name": "agency_user_subAgencyId_idx",
+          "columns": [
+            {
+              "expression": "sub_agency_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agency_user_user_id_user_id_fk": {
+          "name": "agency_user_user_id_user_id_fk",
+          "tableFrom": "agency_user",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "agency_user_sub_agency_id_sub_agency_id_fk": {
+          "name": "agency_user_sub_agency_id_sub_agency_id_fk",
+          "tableFrom": "agency_user",
+          "tableTo": "sub_agency",
+          "columnsFrom": [
+            "sub_agency_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.api_key": {
+      "name": "api_key",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "hashed_key": {
+          "name": "hashed_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "prefix": {
+          "name": "prefix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sub_agency_id": {
+          "name": "sub_agency_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "api_key_userId_idx": {
+          "name": "api_key_userId_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "api_key_hashedKey_idx": {
+          "name": "api_key_hashedKey_idx",
+          "columns": [
+            {
+              "expression": "hashed_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "api_key_subAgencyId_idx": {
+          "name": "api_key_subAgencyId_idx",
+          "columns": [
+            {
+              "expression": "sub_agency_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "api_key_userId_subAgencyId_idx": {
+          "name": "api_key_userId_subAgencyId_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "sub_agency_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "api_key_user_id_user_id_fk": {
+          "name": "api_key_user_id_user_id_fk",
+          "tableFrom": "api_key",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "api_key_sub_agency_id_sub_agency_id_fk": {
+          "name": "api_key_sub_agency_id_sub_agency_id_fk",
+          "tableFrom": "api_key",
+          "tableTo": "sub_agency",
+          "columnsFrom": [
+            "sub_agency_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "api_key_hashed_key_unique": {
+          "name": "api_key_hashed_key_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "hashed_key"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.email_account": {
+      "name": "email_account",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sub_agency_id": {
+          "name": "sub_agency_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "email_provider",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "encrypted_access_token": {
+          "name": "encrypted_access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "encrypted_refresh_token": {
+          "name": "encrypted_refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "token_expires_at": {
+          "name": "token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "email_account_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'connected'"
+        },
+        "daily_quota": {
+          "name": "daily_quota",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 500
+        },
+        "quota_used_today": {
+          "name": "quota_used_today",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "quota_reset_at": {
+          "name": "quota_reset_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_synced_at": {
+          "name": "last_synced_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "email_account_userId_idx": {
+          "name": "email_account_userId_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "email_account_subAgencyId_idx": {
+          "name": "email_account_subAgencyId_idx",
+          "columns": [
+            {
+              "expression": "sub_agency_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "email_account_email_idx": {
+          "name": "email_account_email_idx",
+          "columns": [
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "email_account_status_idx": {
+          "name": "email_account_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "email_account_tokenExpiresAt_idx": {
+          "name": "email_account_tokenExpiresAt_idx",
+          "columns": [
+            {
+              "expression": "token_expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "email_account_user_id_user_id_fk": {
+          "name": "email_account_user_id_user_id_fk",
+          "tableFrom": "email_account",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "email_account_sub_agency_id_sub_agency_id_fk": {
+          "name": "email_account_sub_agency_id_sub_agency_id_fk",
+          "tableFrom": "email_account",
+          "tableTo": "sub_agency",
+          "columnsFrom": [
+            "sub_agency_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.email_campaign": {
+      "name": "email_campaign",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sub_agency_id": {
+          "name": "sub_agency_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "campaign_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "total_recipients": {
+          "name": "total_recipients",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "sent_count": {
+          "name": "sent_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "open_count": {
+          "name": "open_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "click_count": {
+          "name": "click_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "reply_count": {
+          "name": "reply_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "bounce_count": {
+          "name": "bounce_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "unsubscribe_count": {
+          "name": "unsubscribe_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "email_campaign_userId_idx": {
+          "name": "email_campaign_userId_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "email_campaign_subAgencyId_idx": {
+          "name": "email_campaign_subAgencyId_idx",
+          "columns": [
+            {
+              "expression": "sub_agency_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "email_campaign_status_idx": {
+          "name": "email_campaign_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "email_campaign_user_id_user_id_fk": {
+          "name": "email_campaign_user_id_user_id_fk",
+          "tableFrom": "email_campaign",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "email_campaign_sub_agency_id_sub_agency_id_fk": {
+          "name": "email_campaign_sub_agency_id_sub_agency_id_fk",
+          "tableFrom": "email_campaign",
+          "tableTo": "sub_agency",
+          "columnsFrom": [
+            "sub_agency_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.email_event": {
+      "name": "email_event",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "queue_id": {
+          "name": "queue_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tracking_id": {
+          "name": "tracking_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "email_event_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "email_event_queueId_idx": {
+          "name": "email_event_queueId_idx",
+          "columns": [
+            {
+              "expression": "queue_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "email_event_trackingId_idx": {
+          "name": "email_event_trackingId_idx",
+          "columns": [
+            {
+              "expression": "tracking_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "email_event_eventType_idx": {
+          "name": "email_event_eventType_idx",
+          "columns": [
+            {
+              "expression": "event_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "email_event_timestamp_idx": {
+          "name": "email_event_timestamp_idx",
+          "columns": [
+            {
+              "expression": "timestamp",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "email_event_queue_id_email_queue_id_fk": {
+          "name": "email_event_queue_id_email_queue_id_fk",
+          "tableFrom": "email_event",
+          "tableTo": "email_queue",
+          "columnsFrom": [
+            "queue_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.email_queue": {
+      "name": "email_queue",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "campaign_id": {
+          "name": "campaign_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_account_id": {
+          "name": "email_account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "recipient_email": {
+          "name": "recipient_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "recipient_name": {
+          "name": "recipient_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "subject": {
+          "name": "subject",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "body_html": {
+          "name": "body_html",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "body_text": {
+          "name": "body_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scheduled_for": {
+          "name": "scheduled_for",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "status": {
+          "name": "status",
+          "type": "email_queue_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "priority": {
+          "name": "priority",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "attempt_count": {
+          "name": "attempt_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "max_attempts": {
+          "name": "max_attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 3
+        },
+        "last_attempt_at": {
+          "name": "last_attempt_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sent_at": {
+          "name": "sent_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tracking_id": {
+          "name": "tracking_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "email_queue_campaignId_idx": {
+          "name": "email_queue_campaignId_idx",
+          "columns": [
+            {
+              "expression": "campaign_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "email_queue_emailAccountId_idx": {
+          "name": "email_queue_emailAccountId_idx",
+          "columns": [
+            {
+              "expression": "email_account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "email_queue_status_idx": {
+          "name": "email_queue_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "email_queue_scheduledFor_idx": {
+          "name": "email_queue_scheduledFor_idx",
+          "columns": [
+            {
+              "expression": "scheduled_for",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "email_queue_trackingId_idx": {
+          "name": "email_queue_trackingId_idx",
+          "columns": [
+            {
+              "expression": "tracking_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "email_queue_status_scheduledFor_idx": {
+          "name": "email_queue_status_scheduledFor_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "scheduled_for",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "email_queue_campaign_id_email_campaign_id_fk": {
+          "name": "email_queue_campaign_id_email_campaign_id_fk",
+          "tableFrom": "email_queue",
+          "tableTo": "email_campaign",
+          "columnsFrom": [
+            "campaign_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "email_queue_email_account_id_email_account_id_fk": {
+          "name": "email_queue_email_account_id_email_account_id_fk",
+          "tableFrom": "email_queue",
+          "tableTo": "email_account",
+          "columnsFrom": [
+            "email_account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "email_queue_tracking_id_unique": {
+          "name": "email_queue_tracking_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "tracking_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.email_template": {
+      "name": "email_template",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sub_agency_id": {
+          "name": "sub_agency_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subject": {
+          "name": "subject",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "body_html": {
+          "name": "body_html",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "body_text": {
+          "name": "body_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "variables": {
+          "name": "variables",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "email_template_userId_idx": {
+          "name": "email_template_userId_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "email_template_subAgencyId_idx": {
+          "name": "email_template_subAgencyId_idx",
+          "columns": [
+            {
+              "expression": "sub_agency_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "email_template_user_id_user_id_fk": {
+          "name": "email_template_user_id_user_id_fk",
+          "tableFrom": "email_template",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "email_template_sub_agency_id_sub_agency_id_fk": {
+          "name": "email_template_sub_agency_id_sub_agency_id_fk",
+          "tableFrom": "email_template",
+          "tableTo": "sub_agency",
+          "columnsFrom": [
+            "sub_agency_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.email_unsubscribe": {
+      "name": "email_unsubscribe",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "campaign_id": {
+          "name": "campaign_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "email_unsubscribe_email_idx": {
+          "name": "email_unsubscribe_email_idx",
+          "columns": [
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "email_unsubscribe_campaign_id_email_campaign_id_fk": {
+          "name": "email_unsubscribe_campaign_id_email_campaign_id_fk",
+          "tableFrom": "email_unsubscribe",
+          "tableTo": "email_campaign",
+          "columnsFrom": [
+            "campaign_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "email_unsubscribe_email_unique": {
+          "name": "email_unsubscribe_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.reply_followup": {
+      "name": "reply_followup",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "sequence_id": {
+          "name": "sequence_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "contact_id": {
+          "name": "contact_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "recipient_email": {
+          "name": "recipient_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_reply_at": {
+          "name": "last_reply_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_reply_excerpt": {
+          "name": "last_reply_excerpt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scheduled_send_at": {
+          "name": "scheduled_send_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "reply_followup_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'scheduled'"
+        },
+        "template_id": {
+          "name": "template_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sent_queue_id": {
+          "name": "sent_queue_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cancel_reason": {
+          "name": "cancel_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sent_at": {
+          "name": "sent_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "reply_followup_sequenceId_idx": {
+          "name": "reply_followup_sequenceId_idx",
+          "columns": [
+            {
+              "expression": "sequence_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "reply_followup_contactId_idx": {
+          "name": "reply_followup_contactId_idx",
+          "columns": [
+            {
+              "expression": "contact_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "reply_followup_status_idx": {
+          "name": "reply_followup_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "reply_followup_scheduledSendAt_idx": {
+          "name": "reply_followup_scheduledSendAt_idx",
+          "columns": [
+            {
+              "expression": "scheduled_send_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "reply_followup_status_scheduledSendAt_idx": {
+          "name": "reply_followup_status_scheduledSendAt_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "scheduled_send_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "reply_followup_sequence_id_email_campaign_id_fk": {
+          "name": "reply_followup_sequence_id_email_campaign_id_fk",
+          "tableFrom": "reply_followup",
+          "tableTo": "email_campaign",
+          "columnsFrom": [
+            "sequence_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "reply_followup_contact_id_email_queue_id_fk": {
+          "name": "reply_followup_contact_id_email_queue_id_fk",
+          "tableFrom": "reply_followup",
+          "tableTo": "email_queue",
+          "columnsFrom": [
+            "contact_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "reply_followup_template_id_email_template_id_fk": {
+          "name": "reply_followup_template_id_email_template_id_fk",
+          "tableFrom": "reply_followup",
+          "tableTo": "email_template",
+          "columnsFrom": [
+            "template_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "reply_followup_sent_queue_id_email_queue_id_fk": {
+          "name": "reply_followup_sent_queue_id_email_queue_id_fk",
+          "tableFrom": "reply_followup",
+          "tableTo": "email_queue",
+          "columnsFrom": [
+            "sent_queue_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.session": {
+      "name": "session",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "session_userId_idx": {
+          "name": "session_userId_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sub_agency": {
+      "name": "sub_agency",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "parent_agency_id": {
+          "name": "parent_agency_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "owner_id": {
+          "name": "owner_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "sub_agency_ownerId_idx": {
+          "name": "sub_agency_ownerId_idx",
+          "columns": [
+            {
+              "expression": "owner_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sub_agency_parentAgencyId_idx": {
+          "name": "sub_agency_parentAgencyId_idx",
+          "columns": [
+            {
+              "expression": "parent_agency_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "sub_agency_owner_id_user_id_fk": {
+          "name": "sub_agency_owner_id_user_id_fk",
+          "tableFrom": "sub_agency",
+          "tableTo": "user",
+          "columnsFrom": [
+            "owner_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user": {
+      "name": "user",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verification": {
+      "name": "verification",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sub_agency_id": {
+          "name": "sub_agency_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "role": {
+          "name": "role",
+          "type": "role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'member'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "verification_created_by_user_id_fk": {
+          "name": "verification_created_by_user_id_fk",
+          "tableFrom": "verification",
+          "tableTo": "user",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.campaign_status": {
+      "name": "campaign_status",
+      "schema": "public",
+      "values": [
+        "draft",
+        "scheduled",
+        "sending",
+        "completed",
+        "paused"
+      ]
+    },
+    "public.email_account_status": {
+      "name": "email_account_status",
+      "schema": "public",
+      "values": [
+        "connected",
+        "disconnected",
+        "error"
+      ]
+    },
+    "public.email_event_type": {
+      "name": "email_event_type",
+      "schema": "public",
+      "values": [
+        "sent",
+        "opened",
+        "clicked",
+        "replied",
+        "bounced",
+        "unsubscribed"
+      ]
+    },
+    "public.email_provider": {
+      "name": "email_provider",
+      "schema": "public",
+      "values": [
+        "gmail",
+        "outlook",
+        "imap"
+      ]
+    },
+    "public.email_queue_status": {
+      "name": "email_queue_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "processing",
+        "sent",
+        "failed",
+        "bounced"
+      ]
+    },
+    "public.reply_followup_status": {
+      "name": "reply_followup_status",
+      "schema": "public",
+      "values": [
+        "scheduled",
+        "sent",
+        "cancelled"
+      ]
+    },
+    "public.role": {
+      "name": "role",
+      "schema": "public",
+      "values": [
+        "admin",
+        "member",
+        "viewer"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/libs/db/drizzle/meta/_journal.json
+++ b/libs/db/drizzle/meta/_journal.json
@@ -50,6 +50,13 @@
       "when": 1765079266033,
       "tag": "0006_ambitious_ezekiel_stane",
       "breakpoints": true
+    },
+    {
+      "idx": 7,
+      "version": "7",
+      "when": 1777758682271,
+      "tag": "0007_rare_vector",
+      "breakpoints": true
     }
   ]
 }

--- a/libs/db/src/queries.ts
+++ b/libs/db/src/queries.ts
@@ -18,3 +18,4 @@ export * from "./queries/emailCampaign";
 export * from "./queries/emailEvent";
 export * from "./queries/emailTemplate";
 export * from "./queries/emailUnsubscribe";
+export * from "./queries/replyFollowup";

--- a/libs/db/src/queries/replyFollowup.ts
+++ b/libs/db/src/queries/replyFollowup.ts
@@ -1,0 +1,173 @@
+import { and, desc, eq, lte, sql } from "drizzle-orm";
+import { db } from "../client";
+import {
+  emailQueue,
+  emailEvent,
+  replyFollowup,
+  ReplyFollowup,
+  InsertReplyFollowup,
+} from "../schema";
+
+export const createReplyFollowup = async (
+  data: InsertReplyFollowup
+): Promise<ReplyFollowup> => {
+  const results = await db.insert(replyFollowup).values(data).returning();
+  return results[0];
+};
+
+export const getReplyFollowupById = async (
+  id: string
+): Promise<ReplyFollowup | null> => {
+  const results = await db
+    .select()
+    .from(replyFollowup)
+    .where(eq(replyFollowup.id, id))
+    .limit(1);
+  return results[0] || null;
+};
+
+export const getScheduledFollowupsForContact = async (
+  contactId: string
+): Promise<ReplyFollowup[]> => {
+  return await db
+    .select()
+    .from(replyFollowup)
+    .where(
+      and(
+        eq(replyFollowup.contactId, contactId),
+        eq(replyFollowup.status, "scheduled")
+      )
+    );
+};
+
+export const cancelScheduledFollowupsForContact = async (
+  contactId: string,
+  reason: string
+): Promise<number> => {
+  const results = await db
+    .update(replyFollowup)
+    .set({ status: "cancelled", cancelReason: reason, updatedAt: new Date() })
+    .where(
+      and(
+        eq(replyFollowup.contactId, contactId),
+        eq(replyFollowup.status, "scheduled")
+      )
+    )
+    .returning({ id: replyFollowup.id });
+  return results.length;
+};
+
+export const cancelReplyFollowup = async (
+  id: string,
+  reason: string
+): Promise<ReplyFollowup | null> => {
+  const results = await db
+    .update(replyFollowup)
+    .set({ status: "cancelled", cancelReason: reason, updatedAt: new Date() })
+    .where(
+      and(eq(replyFollowup.id, id), eq(replyFollowup.status, "scheduled"))
+    )
+    .returning();
+  return results[0] || null;
+};
+
+export const markReplyFollowupSent = async (
+  id: string,
+  sentQueueId: string
+): Promise<ReplyFollowup | null> => {
+  const results = await db
+    .update(replyFollowup)
+    .set({
+      status: "sent",
+      sentQueueId,
+      sentAt: new Date(),
+      updatedAt: new Date(),
+    })
+    .where(eq(replyFollowup.id, id))
+    .returning();
+  return results[0] || null;
+};
+
+export const getDueScheduledFollowups = async (
+  limit: number = 50,
+  now: Date = new Date()
+): Promise<ReplyFollowup[]> => {
+  return await db
+    .select()
+    .from(replyFollowup)
+    .where(
+      and(
+        eq(replyFollowup.status, "scheduled"),
+        lte(replyFollowup.scheduledSendAt, now)
+      )
+    )
+    .orderBy(replyFollowup.scheduledSendAt)
+    .limit(limit);
+};
+
+export const countPendingFollowupsForCampaigns = async (
+  campaignIds: string[]
+): Promise<number> => {
+  if (campaignIds.length === 0) return 0;
+  const result = await db
+    .select({ count: sql<number>`count(*)::int` })
+    .from(replyFollowup)
+    .where(
+      and(
+        eq(replyFollowup.status, "scheduled"),
+        sql`${replyFollowup.sequenceId} = ANY(${campaignIds})`
+      )
+    );
+  return result[0]?.count || 0;
+};
+
+export const listPendingFollowupsForCampaigns = async (
+  campaignIds: string[],
+  limit: number = 100
+): Promise<ReplyFollowup[]> => {
+  if (campaignIds.length === 0) return [];
+  return await db
+    .select()
+    .from(replyFollowup)
+    .where(
+      and(
+        eq(replyFollowup.status, "scheduled"),
+        sql`${replyFollowup.sequenceId} = ANY(${campaignIds})`
+      )
+    )
+    .orderBy(replyFollowup.scheduledSendAt)
+    .limit(limit);
+};
+
+/**
+ * Returns true if there is a `replied` email_event for this contact (queue id)
+ * with a timestamp strictly after `since`. Used by the worker to cancel a
+ * scheduled follow-up when the prospect has replied again since the row was
+ * created.
+ */
+export const hasReplyAfter = async (
+  contactQueueId: string,
+  since: Date
+): Promise<boolean> => {
+  const results = await db
+    .select({ id: emailEvent.id })
+    .from(emailEvent)
+    .where(
+      and(
+        eq(emailEvent.queueId, contactQueueId),
+        eq(emailEvent.eventType, "replied"),
+        sql`${emailEvent.timestamp} > ${since}`
+      )
+    )
+    .limit(1);
+  return results.length > 0;
+};
+
+export const getOriginalQueueEntry = async (queueId: string) => {
+  const results = await db
+    .select()
+    .from(emailQueue)
+    .where(eq(emailQueue.id, queueId))
+    .limit(1);
+  return results[0] || null;
+};

--- a/libs/db/src/schema.ts
+++ b/libs/db/src/schema.ts
@@ -366,6 +366,49 @@ export const emailUnsubscribe = pgTable(
   ]
 );
 
+// Reply Follow-up enums + table
+// Tracks scheduled follow-up sends for prospects who replied (with question/pricing intent)
+// then went silent. README differentiator: "this is where the follow up actually decides the deal".
+export const replyFollowupStatusEnum = pgEnum("reply_followup_status", ["scheduled", "sent", "cancelled"]);
+
+export const replyFollowup = pgTable(
+  "reply_followup",
+  {
+    id: text("id").primaryKey(),
+    // Sequence in the README maps to "campaign" in the current schema.
+    sequenceId: text("sequence_id")
+      .notNull()
+      .references(() => emailCampaign.id, { onDelete: "cascade" }),
+    // Contact identity within a sequence is the original outbound email_queue row
+    // (carries recipient_email + recipient_name + email account context).
+    contactId: text("contact_id")
+      .notNull()
+      .references(() => emailQueue.id, { onDelete: "cascade" }),
+    recipientEmail: text("recipient_email").notNull(),
+    lastReplyAt: timestamp("last_reply_at").notNull(),
+    lastReplyExcerpt: text("last_reply_excerpt"),
+    scheduledSendAt: timestamp("scheduled_send_at").notNull(),
+    status: replyFollowupStatusEnum("status").notNull().default("scheduled"),
+    templateId: text("template_id").references(() => emailTemplate.id, { onDelete: "set null" }),
+    // Queue row created when the follow-up is dispatched (null until sent).
+    sentQueueId: text("sent_queue_id").references(() => emailQueue.id, { onDelete: "set null" }),
+    cancelReason: text("cancel_reason"),
+    sentAt: timestamp("sent_at"),
+    createdAt: timestamp("created_at").defaultNow().notNull(),
+    updatedAt: timestamp("updated_at")
+      .defaultNow()
+      .$onUpdate(() => new Date())
+      .notNull(),
+  },
+  (table) => [
+    index("reply_followup_sequenceId_idx").on(table.sequenceId),
+    index("reply_followup_contactId_idx").on(table.contactId),
+    index("reply_followup_status_idx").on(table.status),
+    index("reply_followup_scheduledSendAt_idx").on(table.scheduledSendAt),
+    index("reply_followup_status_scheduledSendAt_idx").on(table.status, table.scheduledSendAt),
+  ]
+);
+
 // All Relations (defined after all tables)
 export const userRelations = relations(user, ({ many }) => ({
   sessions: many(session),
@@ -466,6 +509,27 @@ export const emailUnsubscribeRelations = relations(emailUnsubscribe, ({ one }) =
   }),
 }));
 
+export const replyFollowupRelations = relations(replyFollowup, ({ one }) => ({
+  campaign: one(emailCampaign, {
+    fields: [replyFollowup.sequenceId],
+    references: [emailCampaign.id],
+  }),
+  contact: one(emailQueue, {
+    fields: [replyFollowup.contactId],
+    references: [emailQueue.id],
+    relationName: "replyFollowupContact",
+  }),
+  sentQueue: one(emailQueue, {
+    fields: [replyFollowup.sentQueueId],
+    references: [emailQueue.id],
+    relationName: "replyFollowupSentQueue",
+  }),
+  template: one(emailTemplate, {
+    fields: [replyFollowup.templateId],
+    references: [emailTemplate.id],
+  }),
+}));
+
 // Type exports for email system
 export type EmailAccount = typeof emailAccount.$inferSelect;
 export type InsertEmailAccount = typeof emailAccount.$inferInsert;
@@ -479,4 +543,6 @@ export type EmailTemplate = typeof emailTemplate.$inferSelect;
 export type InsertEmailTemplate = typeof emailTemplate.$inferInsert;
 export type EmailUnsubscribe = typeof emailUnsubscribe.$inferSelect;
 export type InsertEmailUnsubscribe = typeof emailUnsubscribe.$inferInsert;
+export type ReplyFollowup = typeof replyFollowup.$inferSelect;
+export type InsertReplyFollowup = typeof replyFollowup.$inferInsert;
 

--- a/src/app/(frontend)/dashboard/follow-ups/page.tsx
+++ b/src/app/(frontend)/dashboard/follow-ups/page.tsx
@@ -1,0 +1,121 @@
+'use client'
+import { useCallback, useEffect, useState } from 'react'
+
+interface FollowupRow {
+  id: string
+  sequenceId: string
+  sequenceName: string | null
+  recipientEmail: string
+  lastReplyAt: string
+  lastReplyExcerpt: string | null
+  scheduledSendAt: string
+  status: 'scheduled' | 'sent' | 'cancelled'
+  createdAt: string
+}
+
+export default function FollowUpsPage() {
+  const [followups, setFollowups] = useState<FollowupRow[]>([])
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+  const [cancellingId, setCancellingId] = useState<string | null>(null)
+
+  const load = useCallback(async () => {
+    setLoading(true)
+    setError(null)
+    try {
+      const res = await fetch('/api/follow-ups')
+      const json = await res.json()
+      if (!json.success) {
+        setError(json.error ?? 'Failed to load')
+        return
+      }
+      setFollowups(json.followups ?? [])
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to load')
+    } finally {
+      setLoading(false)
+    }
+  }, [])
+
+  useEffect(() => {
+    void load()
+  }, [load])
+
+  const cancel = async (id: string) => {
+    setCancellingId(id)
+    try {
+      const res = await fetch(`/api/follow-ups/${id}/cancel`, { method: 'POST' })
+      const json = await res.json()
+      if (!json.success) {
+        setError(json.error ?? 'Failed to cancel')
+        return
+      }
+      setFollowups((current) => current.filter((row) => row.id !== id))
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to cancel')
+    } finally {
+      setCancellingId(null)
+    }
+  }
+
+  return (
+    <div className="p-8">
+      <div className="max-w-5xl mx-auto">
+        <h1 className="text-2xl font-bold mb-2">Pending follow-ups</h1>
+        <p className="text-muted-foreground mb-6">
+          Silent-reply follow-ups scheduled for prospects who replied with a
+          question or pricing/details request and then went quiet.
+        </p>
+
+        {error && (
+          <div className="border border-destructive bg-destructive/10 text-destructive rounded-md p-3 mb-4 text-sm">
+            {error}
+          </div>
+        )}
+
+        {loading ? (
+          <p className="text-muted-foreground">Loading…</p>
+        ) : followups.length === 0 ? (
+          <p className="text-muted-foreground">No pending follow-ups.</p>
+        ) : (
+          <div className="border border-border rounded-md overflow-hidden">
+            <table className="w-full text-sm">
+              <thead className="bg-muted/50 text-left">
+                <tr>
+                  <th className="px-4 py-2 font-medium">Recipient</th>
+                  <th className="px-4 py-2 font-medium">Sequence</th>
+                  <th className="px-4 py-2 font-medium">Reply excerpt</th>
+                  <th className="px-4 py-2 font-medium">Sends at</th>
+                  <th className="px-4 py-2 font-medium" />
+                </tr>
+              </thead>
+              <tbody>
+                {followups.map((row) => (
+                  <tr key={row.id} className="border-t border-border align-top">
+                    <td className="px-4 py-3 break-all">{row.recipientEmail}</td>
+                    <td className="px-4 py-3">{row.sequenceName ?? row.sequenceId}</td>
+                    <td className="px-4 py-3 text-muted-foreground max-w-md">
+                      {row.lastReplyExcerpt ?? '—'}
+                    </td>
+                    <td className="px-4 py-3 whitespace-nowrap">
+                      {new Date(row.scheduledSendAt).toLocaleString()}
+                    </td>
+                    <td className="px-4 py-3 text-right">
+                      <button
+                        onClick={() => cancel(row.id)}
+                        disabled={cancellingId === row.id}
+                        className="px-3 py-1 text-sm border border-border rounded-md hover:bg-muted transition-colors disabled:opacity-50"
+                      >
+                        {cancellingId === row.id ? 'Cancelling…' : 'Cancel'}
+                      </button>
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/src/app/(frontend)/dashboard/page.tsx
+++ b/src/app/(frontend)/dashboard/page.tsx
@@ -1,16 +1,103 @@
 'use client'
+import Link from 'next/link'
+import { useEffect, useState } from 'react'
 import { authClient } from '@/access/authClient'
+
+interface CampaignStats {
+  totalSent: number
+  totalReplied: number
+}
+
+interface FollowupStats {
+  pendingCount: number
+}
 
 export default function DashboardPage() {
   const { data: session } = authClient.useSession()
-  console.log(session)
+  const [campaignStats, setCampaignStats] = useState<CampaignStats | null>(null)
+  const [followupStats, setFollowupStats] = useState<FollowupStats | null>(null)
+
+  useEffect(() => {
+    if (!session?.user) return
+
+    let cancelled = false
+    const load = async () => {
+      try {
+        const [campaignsRes, followupsRes] = await Promise.all([
+          fetch('/api/campaigns?limit=500'),
+          fetch('/api/follow-ups?mode=count'),
+        ])
+        const campaignsJson = await campaignsRes.json()
+        const followupsJson = await followupsRes.json()
+        if (cancelled) return
+        if (campaignsJson?.success) {
+          const campaigns = campaignsJson.campaigns ?? []
+          setCampaignStats({
+            totalSent: campaigns.reduce(
+              (sum: number, c: { sentCount: number }) => sum + (c.sentCount || 0),
+              0,
+            ),
+            totalReplied: campaigns.reduce(
+              (sum: number, c: { replyCount: number }) => sum + (c.replyCount || 0),
+              0,
+            ),
+          })
+        }
+        if (followupsJson?.success) {
+          setFollowupStats({ pendingCount: followupsJson.count ?? 0 })
+        }
+      } catch (err) {
+        console.error('Failed to load dashboard stats', err)
+      }
+    }
+    void load()
+    return () => {
+      cancelled = true
+    }
+  }, [session?.user])
 
   return (
     <div className="p-8">
       <div className="max-w-7xl mx-auto">
-        <h1 className="text-2xl font-bold mb-4">Welcome to your Dashboard</h1>
-        <p className="text-muted-foreground">Logged in as: {session?.user?.email}</p>
+        <h1 className="text-2xl font-bold mb-2">Welcome to your Dashboard</h1>
+        <p className="text-muted-foreground mb-6">Logged in as: {session?.user?.email}</p>
+
+        <div className="grid grid-cols-1 sm:grid-cols-3 gap-4">
+          <StatCard
+            label="Sent"
+            value={campaignStats?.totalSent ?? null}
+          />
+          <StatCard
+            label="Replied"
+            value={campaignStats?.totalReplied ?? null}
+          />
+          <StatCard
+            label="Pending follow-ups"
+            value={followupStats?.pendingCount ?? null}
+            href="/dashboard/follow-ups"
+          />
+        </div>
       </div>
     </div>
   )
+}
+
+function StatCard({
+  label,
+  value,
+  href,
+}: {
+  label: string
+  value: number | null
+  href?: string
+}) {
+  const inner = (
+    <div className="border border-border rounded-md p-4 hover:border-primary transition-colors">
+      <p className="text-sm text-muted-foreground">{label}</p>
+      <p className="text-2xl font-semibold mt-1">
+        {value === null ? '—' : value.toLocaleString()}
+      </p>
+    </div>
+  )
+  return href ? <Link href={href}>{inner}</Link> : inner
 }

--- a/src/app/api/cron/process-followups/route.ts
+++ b/src/app/api/cron/process-followups/route.ts
@@ -1,0 +1,77 @@
+import { NextRequest, NextResponse } from "next/server";
+import { processDueReplyFollowups } from "@/lib/replyFollowup";
+
+/**
+ * POST /api/cron/process-followups
+ *
+ * Cron endpoint for processing scheduled silent-reply follow-ups. Mirrors the
+ * auth shape of /api/cron/process-queue (Bearer CRON_SECRET) so the same cron
+ * runner can hit both.
+ *
+ * Recommended frequency: every 5 minutes.
+ */
+
+export async function POST(request: NextRequest) {
+  try {
+    const authHeader = request.headers.get("authorization");
+    const cronSecret = process.env.CRON_SECRET;
+
+    if (!cronSecret) {
+      console.error("CRON_SECRET not configured");
+      return NextResponse.json(
+        { success: false, error: "Server misconfiguration" },
+        { status: 500 }
+      );
+    }
+
+    if (!authHeader || authHeader !== `Bearer ${cronSecret}`) {
+      return NextResponse.json(
+        { success: false, error: "Unauthorized" },
+        { status: 401 }
+      );
+    }
+
+    const result = await processDueReplyFollowups(50);
+
+    return NextResponse.json({
+      success: true,
+      result: {
+        due: result.due,
+        enqueued: result.enqueued,
+        cancelled: result.cancelled,
+        skipped: result.skipped,
+        errors: result.errors.length > 0 ? result.errors.slice(0, 10) : undefined,
+      },
+    });
+  } catch (error) {
+    console.error("Error in follow-up processing cron:", error);
+
+    return NextResponse.json(
+      {
+        success: false,
+        error: "Failed to process follow-ups",
+        details: error instanceof Error ? error.message : "Unknown error",
+      },
+      { status: 500 }
+    );
+  }
+}
+
+export async function GET(request: NextRequest) {
+  const authHeader = request.headers.get("authorization");
+  const cronSecret = process.env.CRON_SECRET;
+
+  if (!cronSecret || !authHeader || authHeader !== `Bearer ${cronSecret}`) {
+    return NextResponse.json(
+      { success: false, error: "Unauthorized" },
+      { status: 401 }
+    );
+  }
+
+  return NextResponse.json({
+    success: true,
+    message: "Follow-up processing cron endpoint is healthy",
+    endpoint: "/api/cron/process-followups",
+    method: "POST",
+  });
+}

--- a/src/app/api/email-tracking/reply/route.ts
+++ b/src/app/api/email-tracking/reply/route.ts
@@ -1,0 +1,75 @@
+import { NextRequest, NextResponse } from "next/server";
+import { z } from "zod";
+import { getQueueEntryByTrackingId } from "@coldflow/db";
+import { recordInboundReply } from "@/lib/replyFollowup";
+
+/**
+ * POST /api/email-tracking/reply
+ *
+ * Webhook entry point for inbound replies. Whichever pipeline detects a
+ * reply (Gmail watch webhook, IMAP poller, etc.) calls this endpoint with
+ * the original outbound `trackingId` (or `queueId`) plus the reply body.
+ *
+ * Auth: Bearer GMAIL_WEBHOOK_SECRET — same shape used by the rest of
+ * coldflow's tracking surface.
+ */
+
+const InboundReplySchema = z
+  .object({
+    trackingId: z.string().optional(),
+    queueId: z.string().optional(),
+    replyBody: z.string().min(1).max(50000),
+    replyAt: z.string().datetime().optional(),
+  })
+  .refine((data) => data.trackingId || data.queueId, {
+    message: "trackingId or queueId is required",
+  });
+
+export async function POST(request: NextRequest) {
+  const authHeader = request.headers.get("authorization");
+  const secret = process.env.GMAIL_WEBHOOK_SECRET;
+  if (!secret || authHeader !== `Bearer ${secret}`) {
+    return NextResponse.json(
+      { success: false, error: "Unauthorized" },
+      { status: 401 }
+    );
+  }
+
+  try {
+    const body = await request.json();
+    const parsed = InboundReplySchema.parse(body);
+
+    let queueId = parsed.queueId;
+    if (!queueId && parsed.trackingId) {
+      const entry = await getQueueEntryByTrackingId(parsed.trackingId);
+      if (entry) queueId = entry.id;
+    }
+
+    if (!queueId) {
+      return NextResponse.json(
+        { success: false, error: "Could not resolve original queue entry" },
+        { status: 404 }
+      );
+    }
+
+    const result = await recordInboundReply({
+      contactQueueId: queueId,
+      replyBody: parsed.replyBody,
+      replyAt: parsed.replyAt ? new Date(parsed.replyAt) : undefined,
+    });
+
+    return NextResponse.json({ success: true, result });
+  } catch (error) {
+    if (error instanceof z.ZodError) {
+      return NextResponse.json(
+        { success: false, error: "Invalid request", details: error.errors },
+        { status: 400 }
+      );
+    }
+    console.error("Error recording inbound reply:", error);
+    return NextResponse.json(
+      { success: false, error: "Failed to record reply" },
+      { status: 500 }
+    );
+  }
+}

--- a/src/app/api/follow-ups/[id]/cancel/route.ts
+++ b/src/app/api/follow-ups/[id]/cancel/route.ts
@@ -1,0 +1,60 @@
+import { NextRequest, NextResponse } from "next/server";
+import {
+  cancelReplyFollowup,
+  getCampaignById,
+  getReplyFollowupById,
+} from "@coldflow/db";
+import { AuthorizationError, requireAuth } from "@/lib/authorization";
+
+/**
+ * POST /api/follow-ups/:id/cancel
+ *
+ * Cancels a scheduled silent-reply follow-up. Only the campaign owner can cancel.
+ */
+export async function POST(
+  _request: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  try {
+    const user = await requireAuth();
+    const { id } = await params;
+
+    const followup = await getReplyFollowupById(id);
+    if (!followup) {
+      return NextResponse.json(
+        { success: false, error: "Follow-up not found" },
+        { status: 404 }
+      );
+    }
+
+    const campaign = await getCampaignById(followup.sequenceId);
+    if (!campaign || campaign.userId !== user.id) {
+      return NextResponse.json(
+        { success: false, error: "Forbidden" },
+        { status: 403 }
+      );
+    }
+
+    if (followup.status !== "scheduled") {
+      return NextResponse.json(
+        { success: false, error: `Follow-up is already ${followup.status}` },
+        { status: 409 }
+      );
+    }
+
+    const updated = await cancelReplyFollowup(id, "cancelled_by_user");
+    return NextResponse.json({ success: true, followup: updated });
+  } catch (error) {
+    if (error instanceof AuthorizationError) {
+      return NextResponse.json(
+        { success: false, error: error.message },
+        { status: error.statusCode }
+      );
+    }
+    console.error("Error cancelling follow-up:", error);
+    return NextResponse.json(
+      { success: false, error: "Failed to cancel follow-up" },
+      { status: 500 }
+    );
+  }
+}

--- a/src/app/api/follow-ups/route.ts
+++ b/src/app/api/follow-ups/route.ts
@@ -1,0 +1,68 @@
+import { NextRequest, NextResponse } from "next/server";
+import {
+  countPendingFollowupsForCampaigns,
+  getCampaignsByUserId,
+  listPendingFollowupsForCampaigns,
+} from "@coldflow/db";
+import { AuthorizationError, requireAuth } from "@/lib/authorization";
+
+/**
+ * GET /api/follow-ups
+ *
+ * Returns the count and (optionally) a list of `scheduled` reply follow-ups
+ * across the authenticated user's campaigns. Powers the dashboard "Pending
+ * follow-ups" tile and click-through list.
+ *
+ * Query params:
+ *   - mode=count   → return only `{ count }` (cheap, used for the tile)
+ *   - mode=list    → also return `followups` array (default)
+ */
+export async function GET(request: NextRequest) {
+  try {
+    const user = await requireAuth();
+    const mode = request.nextUrl.searchParams.get("mode") ?? "list";
+
+    const campaigns = await getCampaignsByUserId(user.id, { limit: 500 });
+    const campaignIds = campaigns.map((c) => c.id);
+
+    if (mode === "count") {
+      const count = await countPendingFollowupsForCampaigns(campaignIds);
+      return NextResponse.json({ success: true, count });
+    }
+
+    const [count, followups] = await Promise.all([
+      countPendingFollowupsForCampaigns(campaignIds),
+      listPendingFollowupsForCampaigns(campaignIds, 100),
+    ]);
+
+    const campaignNameById = new Map(campaigns.map((c) => [c.id, c.name]));
+
+    return NextResponse.json({
+      success: true,
+      count,
+      followups: followups.map((f) => ({
+        id: f.id,
+        sequenceId: f.sequenceId,
+        sequenceName: campaignNameById.get(f.sequenceId) ?? null,
+        recipientEmail: f.recipientEmail,
+        lastReplyAt: f.lastReplyAt,
+        lastReplyExcerpt: f.lastReplyExcerpt,
+        scheduledSendAt: f.scheduledSendAt,
+        status: f.status,
+        createdAt: f.createdAt,
+      })),
+    });
+  } catch (error) {
+    if (error instanceof AuthorizationError) {
+      return NextResponse.json(
+        { success: false, error: error.message },
+        { status: error.statusCode }
+      );
+    }
+    console.error("Error fetching follow-ups:", error);
+    return NextResponse.json(
+      { success: false, error: "Failed to fetch follow-ups" },
+      { status: 500 }
+    );
+  }
+}

--- a/src/lib/replyFollowup.ts
+++ b/src/lib/replyFollowup.ts
@@ -1,0 +1,216 @@
+import { nanoid } from "nanoid";
+import {
+  cancelScheduledFollowupsForContact,
+  createEmailEvent,
+  createQueueEntry,
+  createReplyFollowup,
+  eventExistsForTracking,
+  getDueScheduledFollowups,
+  getOriginalQueueEntry,
+  hasReplyAfter,
+  incrementCampaignStat,
+  markReplyFollowupSent,
+  cancelReplyFollowup,
+  ReplyFollowup,
+} from "@coldflow/db";
+
+/**
+ * Default offset (in days) between an inbound reply and the silent-reply
+ * follow-up. Tunable via env so prod can dial it without a deploy.
+ */
+const DEFAULT_OFFSET_DAYS = 3;
+
+export const getFollowupOffsetMs = (): number => {
+  const raw = process.env.REPLY_FOLLOWUP_OFFSET_DAYS;
+  const parsed = raw ? Number(raw) : NaN;
+  const days = Number.isFinite(parsed) && parsed > 0 ? parsed : DEFAULT_OFFSET_DAYS;
+  return Math.round(days * 24 * 60 * 60 * 1000);
+};
+
+/**
+ * Keyword heuristic for v1. Matches if the reply contains any pricing/details
+ * cue or a question mark. Intentionally dumb — easy to swap for an LLM call.
+ */
+const HEURISTIC_KEYWORDS = ["pricing", "price", "cost", "details", "more info"];
+
+export const replyMatchesFollowupHeuristic = (replyBody: string): boolean => {
+  if (!replyBody) return false;
+  const normalized = replyBody.toLowerCase();
+  if (normalized.includes("?")) return true;
+  return HEURISTIC_KEYWORDS.some((kw) => normalized.includes(kw));
+};
+
+const EXCERPT_MAX_LENGTH = 280;
+
+const buildExcerpt = (body: string): string => {
+  const collapsed = body.replace(/\s+/g, " ").trim();
+  if (collapsed.length <= EXCERPT_MAX_LENGTH) return collapsed;
+  return `${collapsed.slice(0, EXCERPT_MAX_LENGTH - 1)}…`;
+};
+
+export interface RecordInboundReplyInput {
+  /** id of the original outbound email_queue row this reply is responding to */
+  contactQueueId: string;
+  /** plain-text body (or best-effort plaintext) of the inbound reply */
+  replyBody: string;
+  /** when the reply landed; defaults to now */
+  replyAt?: Date;
+}
+
+export interface RecordInboundReplyResult {
+  followupCreated: boolean;
+  followup?: ReplyFollowup;
+  cancelledExistingCount: number;
+  reason?: "no_queue_entry" | "heuristic_no_match";
+}
+
+/**
+ * Canonical entry point for inbound replies. Writes the `replied` event
+ * (idempotent on tracking_id), bumps the campaign reply count, cancels any
+ * still-scheduled follow-up for this contact (the new reply supersedes it),
+ * and — when the heuristic matches — schedules a silent-reply follow-up.
+ *
+ * Designed to be reused by whichever pipe ends up detecting replies (Gmail
+ * watch webhook, IMAP poller, etc.). Keeping the logic here means we only
+ * have one place that owns the dashboard 'replied' metric and the follow-up
+ * trigger.
+ */
+export const recordInboundReply = async (
+  input: RecordInboundReplyInput
+): Promise<RecordInboundReplyResult> => {
+  const replyAt = input.replyAt ?? new Date();
+  const queueEntry = await getOriginalQueueEntry(input.contactQueueId);
+
+  if (!queueEntry) {
+    return { followupCreated: false, cancelledExistingCount: 0, reason: "no_queue_entry" };
+  }
+
+  const alreadyReplied = await eventExistsForTracking(queueEntry.trackingId, "replied");
+  if (!alreadyReplied) {
+    await createEmailEvent({
+      id: nanoid(),
+      queueId: queueEntry.id,
+      trackingId: queueEntry.trackingId,
+      eventType: "replied",
+      timestamp: replyAt,
+      metadata: { excerpt: buildExcerpt(input.replyBody) },
+    });
+    await incrementCampaignStat(queueEntry.campaignId, "replyCount");
+  }
+
+  const cancelledExistingCount = await cancelScheduledFollowupsForContact(
+    queueEntry.id,
+    "superseded_by_new_reply"
+  );
+
+  if (!replyMatchesFollowupHeuristic(input.replyBody)) {
+    return {
+      followupCreated: false,
+      cancelledExistingCount,
+      reason: "heuristic_no_match",
+    };
+  }
+
+  const followup = await createReplyFollowup({
+    id: nanoid(),
+    sequenceId: queueEntry.campaignId,
+    contactId: queueEntry.id,
+    recipientEmail: queueEntry.recipientEmail,
+    lastReplyAt: replyAt,
+    lastReplyExcerpt: buildExcerpt(input.replyBody),
+    scheduledSendAt: new Date(replyAt.getTime() + getFollowupOffsetMs()),
+    status: "scheduled",
+  });
+
+  return { followupCreated: true, followup, cancelledExistingCount };
+};
+
+const SILENT_FOLLOWUP_SUBJECT_PREFIX = "Re: ";
+const SILENT_FOLLOWUP_BODY = (recipientName?: string | null) => {
+  const greeting = recipientName ? `Hi ${recipientName.split(" ")[0]},` : "Hi,";
+  return [
+    greeting,
+    "",
+    "Just bumping this up — wanted to make sure my last note didn't get buried.",
+    "Happy to send over the details / pricing whenever it's useful, or jump on a quick call if that's easier.",
+    "",
+    "Thanks!",
+  ].join("\n");
+};
+
+export interface ProcessFollowupsResult {
+  due: number;
+  enqueued: number;
+  cancelled: number;
+  skipped: number;
+  errors: string[];
+}
+
+/**
+ * Process scheduled follow-ups whose send time has arrived. For each row:
+ *   - if the prospect has replied again since `last_reply_at` → mark cancelled
+ *   - else enqueue a short silent-reply follow-up email and mark the row sent
+ *
+ * Returns a summary suitable for cron logging / API response.
+ */
+export const processDueReplyFollowups = async (
+  limit: number = 50,
+  now: Date = new Date()
+): Promise<ProcessFollowupsResult> => {
+  const result: ProcessFollowupsResult = {
+    due: 0,
+    enqueued: 0,
+    cancelled: 0,
+    skipped: 0,
+    errors: [],
+  };
+
+  const due = await getDueScheduledFollowups(limit, now);
+  result.due = due.length;
+  if (due.length === 0) return result;
+
+  for (const row of due) {
+    try {
+      const replied = await hasReplyAfter(row.contactId, row.lastReplyAt);
+      if (replied) {
+        await cancelReplyFollowup(row.id, "new_reply_received");
+        result.cancelled++;
+        continue;
+      }
+
+      const original = await getOriginalQueueEntry(row.contactId);
+      if (!original) {
+        await cancelReplyFollowup(row.id, "original_queue_missing");
+        result.skipped++;
+        continue;
+      }
+
+      const subject = original.subject.startsWith(SILENT_FOLLOWUP_SUBJECT_PREFIX)
+        ? original.subject
+        : `${SILENT_FOLLOWUP_SUBJECT_PREFIX}${original.subject}`;
+      const bodyText = SILENT_FOLLOWUP_BODY(original.recipientName);
+
+      const queueEntry = await createQueueEntry({
+        id: nanoid(),
+        campaignId: original.campaignId,
+        emailAccountId: original.emailAccountId,
+        recipientEmail: original.recipientEmail,
+        recipientName: original.recipientName,
+        subject,
+        bodyText,
+        bodyHtml: null,
+        scheduledFor: now,
+        status: "pending",
+        trackingId: nanoid(),
+      });
+
+      await markReplyFollowupSent(row.id, queueEntry.id);
+      result.enqueued++;
+    } catch (err) {
+      const message = err instanceof Error ? err.message : "unknown error";
+      result.errors.push(`${row.id}: ${message}`);
+    }
+  }
+
+  return result;
+};

--- a/tests/int/replyFollowup.int.spec.ts
+++ b/tests/int/replyFollowup.int.spec.ts
@@ -1,0 +1,263 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+
+vi.mock('nanoid', () => ({
+  nanoid: () => `id-${Math.random().toString(36).slice(2)}`,
+}))
+
+const { dbMock } = vi.hoisted(() => ({
+  dbMock: {
+    cancelScheduledFollowupsForContact: vi.fn(),
+    createEmailEvent: vi.fn(),
+    createQueueEntry: vi.fn(),
+    createReplyFollowup: vi.fn(),
+    eventExistsForTracking: vi.fn(),
+    getDueScheduledFollowups: vi.fn(),
+    getOriginalQueueEntry: vi.fn(),
+    hasReplyAfter: vi.fn(),
+    incrementCampaignStat: vi.fn(),
+    markReplyFollowupSent: vi.fn(),
+    cancelReplyFollowup: vi.fn(),
+  },
+}))
+
+vi.mock('@coldflow/db', () => dbMock)
+
+import {
+  getFollowupOffsetMs,
+  processDueReplyFollowups,
+  recordInboundReply,
+  replyMatchesFollowupHeuristic,
+} from '@/lib/replyFollowup'
+
+beforeEach(() => {
+  for (const fn of Object.values(dbMock)) {
+    fn.mockReset()
+  }
+  delete process.env.REPLY_FOLLOWUP_OFFSET_DAYS
+})
+
+describe('replyMatchesFollowupHeuristic', () => {
+  it('matches replies with a question mark', () => {
+    expect(replyMatchesFollowupHeuristic('Sounds great. Got time tomorrow?')).toBe(true)
+  })
+
+  it('matches pricing/cost/details/more info keywords case-insensitively', () => {
+    expect(replyMatchesFollowupHeuristic('Send pricing')).toBe(true)
+    expect(replyMatchesFollowupHeuristic('what does it COST')).toBe(true)
+    expect(replyMatchesFollowupHeuristic('Yes please send Details')).toBe(true)
+    expect(replyMatchesFollowupHeuristic('need more info before deciding')).toBe(true)
+    expect(replyMatchesFollowupHeuristic('What is the price for 50 seats')).toBe(true)
+  })
+
+  it('does not match replies without cues', () => {
+    expect(replyMatchesFollowupHeuristic('thanks but not interested.')).toBe(false)
+    expect(replyMatchesFollowupHeuristic('please remove me from this list.')).toBe(false)
+    expect(replyMatchesFollowupHeuristic('')).toBe(false)
+  })
+})
+
+describe('getFollowupOffsetMs', () => {
+  it('defaults to 3 days', () => {
+    expect(getFollowupOffsetMs()).toBe(3 * 24 * 60 * 60 * 1000)
+  })
+
+  it('honours REPLY_FOLLOWUP_OFFSET_DAYS env var', () => {
+    process.env.REPLY_FOLLOWUP_OFFSET_DAYS = '5'
+    expect(getFollowupOffsetMs()).toBe(5 * 24 * 60 * 60 * 1000)
+  })
+
+  it('falls back to default for non-positive or invalid values', () => {
+    process.env.REPLY_FOLLOWUP_OFFSET_DAYS = '-2'
+    expect(getFollowupOffsetMs()).toBe(3 * 24 * 60 * 60 * 1000)
+    process.env.REPLY_FOLLOWUP_OFFSET_DAYS = 'banana'
+    expect(getFollowupOffsetMs()).toBe(3 * 24 * 60 * 60 * 1000)
+  })
+})
+
+describe('recordInboundReply', () => {
+  const queueEntry = {
+    id: 'queue-1',
+    campaignId: 'campaign-1',
+    trackingId: 'track-1',
+    recipientEmail: 'prospect@example.com',
+    recipientName: 'Pat',
+    subject: 'Quick question',
+  }
+
+  it('writes a replied event, increments campaign reply count, and schedules a followup when heuristic matches', async () => {
+    dbMock.getOriginalQueueEntry.mockResolvedValueOnce(queueEntry)
+    dbMock.eventExistsForTracking.mockResolvedValueOnce(false)
+    dbMock.cancelScheduledFollowupsForContact.mockResolvedValueOnce(0)
+    dbMock.createReplyFollowup.mockResolvedValueOnce({
+      id: 'followup-1',
+      sequenceId: 'campaign-1',
+      contactId: 'queue-1',
+      status: 'scheduled',
+    })
+
+    const replyAt = new Date('2026-05-01T10:00:00Z')
+    const result = await recordInboundReply({
+      contactQueueId: 'queue-1',
+      replyBody: 'Could you share pricing?',
+      replyAt,
+    })
+
+    expect(result.followupCreated).toBe(true)
+    expect(dbMock.createEmailEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        queueId: 'queue-1',
+        trackingId: 'track-1',
+        eventType: 'replied',
+        timestamp: replyAt,
+      })
+    )
+    expect(dbMock.incrementCampaignStat).toHaveBeenCalledWith('campaign-1', 'replyCount')
+    expect(dbMock.cancelScheduledFollowupsForContact).toHaveBeenCalledWith(
+      'queue-1',
+      'superseded_by_new_reply'
+    )
+    const insert = dbMock.createReplyFollowup.mock.calls[0][0]
+    expect(insert).toMatchObject({
+      sequenceId: 'campaign-1',
+      contactId: 'queue-1',
+      recipientEmail: 'prospect@example.com',
+      lastReplyAt: replyAt,
+      status: 'scheduled',
+    })
+    const expectedSendAt = new Date(replyAt.getTime() + 3 * 24 * 60 * 60 * 1000)
+    expect((insert.scheduledSendAt as Date).getTime()).toBe(expectedSendAt.getTime())
+  })
+
+  it('does not create a followup when the heuristic does not match (but still records the reply)', async () => {
+    dbMock.getOriginalQueueEntry.mockResolvedValueOnce(queueEntry)
+    dbMock.eventExistsForTracking.mockResolvedValueOnce(false)
+    dbMock.cancelScheduledFollowupsForContact.mockResolvedValueOnce(0)
+
+    const result = await recordInboundReply({
+      contactQueueId: 'queue-1',
+      replyBody: 'thanks but not a fit right now',
+    })
+
+    expect(result.followupCreated).toBe(false)
+    expect(result.reason).toBe('heuristic_no_match')
+    expect(dbMock.createReplyFollowup).not.toHaveBeenCalled()
+    expect(dbMock.createEmailEvent).toHaveBeenCalled()
+  })
+
+  it('cancels existing scheduled followups when a new reply arrives (cancel-on-new-reply rule)', async () => {
+    dbMock.getOriginalQueueEntry.mockResolvedValueOnce(queueEntry)
+    dbMock.eventExistsForTracking.mockResolvedValueOnce(true)
+    dbMock.cancelScheduledFollowupsForContact.mockResolvedValueOnce(1)
+    dbMock.createReplyFollowup.mockResolvedValueOnce({
+      id: 'followup-2',
+      sequenceId: 'campaign-1',
+      contactId: 'queue-1',
+      status: 'scheduled',
+    })
+
+    const result = await recordInboundReply({
+      contactQueueId: 'queue-1',
+      replyBody: 'Actually, can you clarify pricing once more?',
+    })
+
+    expect(dbMock.cancelScheduledFollowupsForContact).toHaveBeenCalledWith(
+      'queue-1',
+      'superseded_by_new_reply'
+    )
+    expect(result.cancelledExistingCount).toBe(1)
+    // duplicate reply event suppressed
+    expect(dbMock.createEmailEvent).not.toHaveBeenCalled()
+    expect(dbMock.incrementCampaignStat).not.toHaveBeenCalled()
+    // new heuristic-matching reply still schedules a fresh follow-up
+    expect(dbMock.createReplyFollowup).toHaveBeenCalledTimes(1)
+    expect(result.followupCreated).toBe(true)
+  })
+
+  it('returns no_queue_entry when the original outbound row cannot be found', async () => {
+    dbMock.getOriginalQueueEntry.mockResolvedValueOnce(null)
+    const result = await recordInboundReply({
+      contactQueueId: 'missing',
+      replyBody: 'price?',
+    })
+    expect(result).toEqual({
+      followupCreated: false,
+      cancelledExistingCount: 0,
+      reason: 'no_queue_entry',
+    })
+    expect(dbMock.createEmailEvent).not.toHaveBeenCalled()
+    expect(dbMock.createReplyFollowup).not.toHaveBeenCalled()
+  })
+})
+
+describe('processDueReplyFollowups', () => {
+  const dueRow = {
+    id: 'followup-1',
+    sequenceId: 'campaign-1',
+    contactId: 'queue-1',
+    recipientEmail: 'prospect@example.com',
+    lastReplyAt: new Date('2026-04-25T09:00:00Z'),
+    lastReplyExcerpt: 'price?',
+    scheduledSendAt: new Date('2026-04-28T09:00:00Z'),
+    status: 'scheduled' as const,
+  }
+
+  it('cancels the row when the prospect has replied again since lastReplyAt', async () => {
+    dbMock.getDueScheduledFollowups.mockResolvedValueOnce([dueRow])
+    dbMock.hasReplyAfter.mockResolvedValueOnce(true)
+    dbMock.cancelReplyFollowup.mockResolvedValueOnce({ ...dueRow, status: 'cancelled' })
+
+    const result = await processDueReplyFollowups(10, new Date('2026-04-28T10:00:00Z'))
+
+    expect(result.cancelled).toBe(1)
+    expect(result.enqueued).toBe(0)
+    expect(dbMock.cancelReplyFollowup).toHaveBeenCalledWith(
+      'followup-1',
+      'new_reply_received'
+    )
+    expect(dbMock.createQueueEntry).not.toHaveBeenCalled()
+    expect(dbMock.markReplyFollowupSent).not.toHaveBeenCalled()
+  })
+
+  it('enqueues a silent-reply email and marks the row sent when no new reply', async () => {
+    dbMock.getDueScheduledFollowups.mockResolvedValueOnce([dueRow])
+    dbMock.hasReplyAfter.mockResolvedValueOnce(false)
+    dbMock.getOriginalQueueEntry.mockResolvedValueOnce({
+      id: 'queue-1',
+      campaignId: 'campaign-1',
+      emailAccountId: 'account-1',
+      recipientEmail: 'prospect@example.com',
+      recipientName: 'Pat Example',
+      subject: 'Quick question',
+      trackingId: 'track-1',
+    })
+    dbMock.createQueueEntry.mockResolvedValueOnce({ id: 'queue-2' })
+    dbMock.markReplyFollowupSent.mockResolvedValueOnce({ ...dueRow, status: 'sent' })
+
+    const result = await processDueReplyFollowups(10, new Date('2026-04-28T10:00:00Z'))
+
+    expect(result.enqueued).toBe(1)
+    expect(result.cancelled).toBe(0)
+    expect(dbMock.createQueueEntry).toHaveBeenCalledWith(
+      expect.objectContaining({
+        campaignId: 'campaign-1',
+        emailAccountId: 'account-1',
+        recipientEmail: 'prospect@example.com',
+        subject: 'Re: Quick question',
+        status: 'pending',
+      })
+    )
+    expect(dbMock.markReplyFollowupSent).toHaveBeenCalledWith('followup-1', 'queue-2')
+  })
+
+  it('returns early when nothing is due', async () => {
+    dbMock.getDueScheduledFollowups.mockResolvedValueOnce([])
+    const result = await processDueReplyFollowups()
+    expect(result).toEqual({
+      due: 0,
+      enqueued: 0,
+      cancelled: 0,
+      skipped: 0,
+      errors: [],
+    })
+  })
+})


### PR DESCRIPTION
## Summary
Implements the README's strategic differentiator: when a prospect replies asking for pricing/details (or any question) and then goes silent, automatically schedule a single short follow-up 3 days later. The follow-up cancels itself if the prospect replies again before it sends.

## What's in this PR

- **Migration 0007**: new `reply_followup` table — `sequenceId` (FK → `email_campaign`), `contactId` (FK → `email_queue`), `last_reply_at`, `last_reply_excerpt`, `scheduled_send_at`, `status` (`scheduled`/`sent`/`cancelled`), nullable `template_id`, plus `sent_queue_id` / `cancel_reason` for traceability.
- **`recordInboundReply()`** (`src/lib/replyFollowup.ts`): canonical entry for inbound replies. Writes the `replied` event (idempotent on `tracking_id`), bumps the campaign `replyCount`, cancels any superseded scheduled follow-ups, and (when the heuristic matches) inserts a `reply_followup` row.
- **Heuristic (v1)**: case-insensitive match on `pricing` / `price` / `cost` / `details` / `more info` / `?`. Intentionally dumb — easy to swap for an LLM call later.
- **`/api/cron/process-followups`**: cron worker. For each due row, if there's been a new reply since `last_reply_at` → mark `cancelled`; otherwise enqueue a short silent-reply email through the existing `email_queue` and mark the row `sent`. Same `Bearer CRON_SECRET` auth shape as `/api/cron/process-queue`.
- **`/api/email-tracking/reply`**: webhook entry point so whichever pipe ends up detecting replies (Gmail watch, IMAP poller, etc.) calls one place. Auth: `Bearer GMAIL_WEBHOOK_SECRET`.
- **Dashboard**: `/dashboard` now shows tiles for `Sent` / `Replied` / `Pending follow-ups`. The pending tile click-throughs to `/dashboard/follow-ups` (list + per-row cancel button).
- **Tunable offset**: `REPLY_FOLLOWUP_OFFSET_DAYS` env var (default 3) so prod can dial it without a deploy.
- **Tests**: `tests/int/replyFollowup.int.spec.ts` — heuristic coverage, env-var fallback, cancel-on-new-reply rule, worker enqueue/cancel paths. 13/13 passing.
- **README**: new MVP bullet for silent-reply follow-up.

## Out of scope (per ticket)
AI-generated bodies, multi-step silent follow-ups, tone matching. Wedge first.

## Test plan
- [x] `pnpm exec vitest run tests/int/replyFollowup.int.spec.ts` — 13 passing
- [ ] On a fresh `pnpm dev` setup, run `pnpm db:migrate` — 0007 applies cleanly
- [ ] POST to `/api/email-tracking/reply` with a body containing "pricing?" → row appears in **Pending follow-ups** with `scheduled_send_at = lastReplyAt + 3d`
- [ ] POST a second reply for the same `queueId` → existing scheduled follow-up gets cancelled (cancel-on-new-reply)
- [ ] Trigger `/api/cron/process-followups` after the send time → row marked `sent` and a new entry appears in `email_queue` for the recipient

Closes HIR-76.