### PR TITLE
README: link to dmarc-doctor as standalone CLI option

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,9 @@
 # MVP features:
 
 ✅ - enter a domain and see SPF / dkim / dmarc records
+   <sub>Want this without spinning up coldflow? Use the standalone CLI:
+   [`npx dmarc-doctor yourdomain.com`](https://github.com/pypesdev/dmarc-doctor) —
+   same checker, zero deps, prints colored verdicts plus 'how to fix'.</sub>
 - connect google smtp accounts
 - upload a csv of contacts
 - Create a single-step email sequence with basic personalization ({first_name}).


### PR DESCRIPTION
## Summary
- Adds a one-line note under the existing `✅ enter a domain and see SPF / dkim / dmarc records` MVP feature, pointing readers to [`pypesdev/dmarc-doctor`](https://github.com/pypesdev/dmarc-doctor) as the `npx`-runnable standalone version.
- Coldflow's deliverability checker was extracted into pure functions in dmarc-doctor (HIR-81). Surfacing the link here completes the cross-link so devs who only want the diagnostic can run it without spinning up coldflow.

## Test plan
- [x] README diff is tiny and renders correctly on github.com (one feature bullet plus a `<sub>` follow-up line)
- [x] Link target https://github.com/pypesdev/dmarc-doctor exists and is public

🤖 Generated with [Claude Code](https://claude.com/claude-code)