### PR TITLE
README: link to smtp-warmer for self-hosted-relay troubleshooting

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,10 @@
 
 ✅ - enter a domain and see SPF / dkim / dmarc records
 - connect google smtp accounts
+   <sub>Mail landing in spam from a self-hosted relay? Diagnose the transport
+   layer in 30s with [`npx smtp-warmer test --host smtp.example.com --port 587 --user me@example.com`](https://github.com/pypesdev/smtp-warmer)
+   — TLS handshake, AUTH+RCPT sandbox (no mail sent), DNSBL reputation,
+   reverse-DNS alignment. Zero deps, zero API keys, composite 0–10 score.</sub>
 - upload a csv of contacts
 - Create a single-step email sequence with basic personalization ({first_name}).
 - Send the emails (with a strict, safe sending limit).


### PR DESCRIPTION
## Summary

- Adds a sub-bullet under "connect google smtp accounts" pointing at [`pypesdev/smtp-warmer`](https://github.com/pypesdev/smtp-warmer) — the new 30-second outbound SMTP self-test CLI.
- Catches users at the moment they wonder "why is my mail landing in spam?". One `npx` command checks TLS, AUTH+RCPT sandbox, DNSBL reputation, and reverse-DNS alignment. Composite 0–10 score.
- Mirrors the dmarc-doctor sub-bullet pattern from PR #6 under the SPF/DKIM/DMARC line.

## Where it sits in the deliverability stack

| Tool | Layer | When to reach for it |
| --- | --- | --- |
| [`dmarc-doctor`](https://github.com/pypesdev/dmarc-doctor) | DNS records | "Are SPF/DKIM/DMARC published correctly?" |
| **`smtp-warmer`** (new) | Live SMTP transport | "Why does my own relay land in spam?" |
| `inbox-warmer` (coming) | Ongoing reputation | "I just spun up a new domain — warm it for weeks." |

## Test plan

- [ ] Render the README on github.com and confirm the new sub-bullet appears under "connect google smtp accounts" with the inline `npx` invocation rendered as inline code, and the link resolves to https://github.com/pypesdev/smtp-warmer
- [ ] Confirm no other content (numbered TODO sections, MVP checklist) shifted unexpectedly

🤖 Generated with [Claude Code](https://claude.com/claude-code)