### PR TITLE
hir-94: wire campaign create UI submit + recipient parser

### DIFF
--- a/src/app/(frontend)/dashboard/campaigns/new/page.tsx
+++ b/src/app/(frontend)/dashboard/campaigns/new/page.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { Suspense, useCallback, useEffect, useState } from 'react'
+import { Suspense, useCallback, useEffect, useMemo, useState } from 'react'
 import { useSearchParams } from 'next/navigation'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
@@ -18,6 +18,20 @@ import {
   getTemplateById,
   type EmailTemplate,
 } from '@/lib/templates/catalog'
+import { parseRecipients } from '@/lib/recipientParser'
+
+type EmailAccount = {
+  id: string
+  email: string
+  provider: string
+  status: string
+}
+
+type SubmitResult =
+  | { kind: 'idle' }
+  | { kind: 'submitting' }
+  | { kind: 'success'; campaignId: string; queued: number }
+  | { kind: 'error'; message: string }
 
 function NewCampaignPageInner() {
   const searchParams = useSearchParams()
@@ -25,17 +39,19 @@ function NewCampaignPageInner() {
   const [subject, setSubject] = useState('')
   const [body, setBody] = useState('')
   const [variables, setVariables] = useState<string[]>([])
+  const [recipientsInput, setRecipientsInput] = useState('')
   const [pickerOpen, setPickerOpen] = useState(false)
+  const [accounts, setAccounts] = useState<EmailAccount[]>([])
+  const [accountsError, setAccountsError] = useState<string | null>(null)
+  const [emailAccountId, setEmailAccountId] = useState('')
+  const [submit, setSubmit] = useState<SubmitResult>({ kind: 'idle' })
 
-  const applyTemplate = useCallback(
-    (template: EmailTemplate) => {
-      setSubject(template.subject)
-      setBody(template.body)
-      setVariables(template.variables)
-      setName((current) => current || template.name)
-    },
-    [],
-  )
+  const applyTemplate = useCallback((template: EmailTemplate) => {
+    setSubject(template.subject)
+    setBody(template.body)
+    setVariables(template.variables)
+    setName((current) => current || template.name)
+  }, [])
 
   useEffect(() => {
     const id = searchParams.get('templateId')
@@ -43,6 +59,73 @@ function NewCampaignPageInner() {
     const template = getTemplateById(id)
     if (template) applyTemplate(template)
   }, [searchParams, applyTemplate])
+
+  useEffect(() => {
+    let cancelled = false
+    fetch('/api/email-accounts')
+      .then(async (res) => {
+        const data = await res.json().catch(() => ({}))
+        if (!res.ok || !data?.success) {
+          throw new Error(data?.error || `Failed to load (${res.status})`)
+        }
+        return data.accounts as EmailAccount[]
+      })
+      .then((list) => {
+        if (cancelled) return
+        const connected = list.filter((a) => a.status === 'connected')
+        setAccounts(connected)
+        if (connected.length === 1) setEmailAccountId(connected[0].id)
+      })
+      .catch((err) => {
+        if (cancelled) return
+        setAccountsError(err instanceof Error ? err.message : String(err))
+      })
+    return () => {
+      cancelled = true
+    }
+  }, [])
+
+  const parsed = useMemo(() => parseRecipients(recipientsInput), [recipientsInput])
+  const canSubmit =
+    submit.kind !== 'submitting' &&
+    name.trim().length > 0 &&
+    subject.trim().length > 0 &&
+    body.trim().length > 0 &&
+    parsed.recipients.length > 0 &&
+    emailAccountId.length > 0
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault()
+    if (!canSubmit) return
+    setSubmit({ kind: 'submitting' })
+    try {
+      const res = await fetch('/api/campaigns', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({
+          name: name.trim(),
+          emailAccountId,
+          recipients: parsed.recipients,
+          subject: subject.trim(),
+          bodyText: body,
+        }),
+      })
+      const data = await res.json().catch(() => ({}))
+      if (!res.ok || !data?.success) {
+        throw new Error(data?.error || `Request failed (${res.status})`)
+      }
+      setSubmit({
+        kind: 'success',
+        campaignId: data.campaign?.id ?? '',
+        queued: data.queuedEmails ?? parsed.recipients.length,
+      })
+    } catch (err) {
+      setSubmit({
+        kind: 'error',
+        message: err instanceof Error ? err.message : String(err),
+      })
+    }
+  }
 
   return (
     <div className="p-8">
@@ -65,7 +148,7 @@ function NewCampaignPageInner() {
           </Button>
         </header>
 
-        <form className="space-y-4">
+        <form className="space-y-4" onSubmit={handleSubmit}>
           <div>
             <Label htmlFor="campaign-name">Name</Label>
             <Input
@@ -74,6 +157,61 @@ function NewCampaignPageInner() {
               onChange={(e) => setName(e.target.value)}
               placeholder="e.g. SaaS onboarding — May launch"
             />
+          </div>
+
+          <div>
+            <Label htmlFor="campaign-account">Send from</Label>
+            {accountsError ? (
+              <p className="text-sm text-red-600 mt-1">
+                Couldn&apos;t load accounts: {accountsError}
+              </p>
+            ) : accounts.length === 0 ? (
+              <p className="text-sm text-muted-foreground mt-1">
+                No connected email accounts.{' '}
+                <a className="underline" href="/dashboard/email-accounts">
+                  Connect one
+                </a>{' '}
+                to send.
+              </p>
+            ) : (
+              <select
+                id="campaign-account"
+                className="w-full mt-1 rounded border bg-background px-3 py-2 text-sm"
+                value={emailAccountId}
+                onChange={(e) => setEmailAccountId(e.target.value)}
+              >
+                <option value="" disabled>
+                  Choose a connected account
+                </option>
+                {accounts.map((a) => (
+                  <option key={a.id} value={a.id}>
+                    {a.email} ({a.provider})
+                  </option>
+                ))}
+              </select>
+            )}
+          </div>
+
+          <div>
+            <Label htmlFor="campaign-recipients">Recipients</Label>
+            <Textarea
+              id="campaign-recipients"
+              value={recipientsInput}
+              onChange={(e) => setRecipientsInput(e.target.value)}
+              rows={6}
+              placeholder={'alice@example.com\nBob Smith <bob@example.com>'}
+            />
+            <p className="text-xs text-muted-foreground mt-1">
+              One per line, comma, or semicolon. Optional{' '}
+              <code className="text-xs">Name &lt;email&gt;</code> form.
+              Parsed: <strong>{parsed.recipients.length}</strong> valid
+              {parsed.invalid.length > 0 && (
+                <>
+                  , <span className="text-red-600">{parsed.invalid.length} invalid</span>
+                </>
+              )}
+              .
+            </p>
           </div>
 
           <div>
@@ -112,6 +250,20 @@ function NewCampaignPageInner() {
               </div>
             </div>
           )}
+
+          <div className="flex items-center gap-3 pt-2">
+            <Button type="submit" disabled={!canSubmit}>
+              {submit.kind === 'submitting' ? 'Creating…' : 'Create campaign'}
+            </Button>
+            {submit.kind === 'success' && (
+              <span className="text-sm text-green-600">
+                Queued {submit.queued} email{submit.queued === 1 ? '' : 's'}.
+              </span>
+            )}
+            {submit.kind === 'error' && (
+              <span className="text-sm text-red-600">{submit.message}</span>
+            )}
+          </div>
         </form>
 
         <Dialog open={pickerOpen} onOpenChange={setPickerOpen}>

--- a/src/lib/recipientParser.ts
+++ b/src/lib/recipientParser.ts
@@ -1,0 +1,74 @@
+export type ParsedRecipient = {
+  email: string
+  name?: string
+}
+
+export type RecipientParseResult = {
+  recipients: ParsedRecipient[]
+  invalid: string[]
+}
+
+const EMAIL_PATTERN = /^[^\s@]+@[^\s@]+\.[^\s@]+$/
+
+export function parseRecipients(input: string): RecipientParseResult {
+  const recipients: ParsedRecipient[] = []
+  const invalid: string[] = []
+  const seen = new Set<string>()
+
+  for (const segment of splitSegments(input)) {
+    const trimmed = segment.trim()
+    if (!trimmed) continue
+
+    let email: string
+    let name: string | undefined
+
+    const angleStart = trimmed.lastIndexOf('<')
+    const angleEnd = trimmed.lastIndexOf('>')
+    if (angleStart !== -1 && angleEnd > angleStart) {
+      const rawName = trimmed.slice(0, angleStart).trim()
+      email = trimmed.slice(angleStart + 1, angleEnd).trim()
+      name =
+        rawName
+          .replace(/^"(.*)"$/, '$1')
+          .trim() || undefined
+    } else {
+      email = trimmed
+    }
+
+    if (!EMAIL_PATTERN.test(email)) {
+      invalid.push(trimmed)
+      continue
+    }
+
+    const key = email.toLowerCase()
+    if (seen.has(key)) continue
+    seen.add(key)
+
+    recipients.push(name ? { email, name } : { email })
+  }
+
+  return { recipients, invalid }
+}
+
+function splitSegments(input: string): string[] {
+  const segments: string[] = []
+  let buf = ''
+  let inQuotes = false
+
+  for (let i = 0; i < input.length; i++) {
+    const ch = input[i]
+    if (ch === '"') {
+      inQuotes = !inQuotes
+      buf += ch
+      continue
+    }
+    if (!inQuotes && (ch === '\n' || ch === ',' || ch === ';')) {
+      segments.push(buf)
+      buf = ''
+      continue
+    }
+    buf += ch
+  }
+  if (buf) segments.push(buf)
+  return segments
+}

--- a/tests/int/recipientParser.int.spec.ts
+++ b/tests/int/recipientParser.int.spec.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from 'vitest'
+import { parseRecipients } from '@/lib/recipientParser'
+
+describe('parseRecipients', () => {
+  it('parses bare emails one per line', () => {
+    const r = parseRecipients('alice@example.com\nbob@example.com')
+    expect(r.recipients).toEqual([
+      { email: 'alice@example.com' },
+      { email: 'bob@example.com' },
+    ])
+    expect(r.invalid).toEqual([])
+  })
+
+  it('parses Name <email> angle format', () => {
+    const r = parseRecipients('Alice Smith <alice@example.com>')
+    expect(r.recipients).toEqual([
+      { email: 'alice@example.com', name: 'Alice Smith' },
+    ])
+  })
+
+  it('strips quotes around angle-format names', () => {
+    const r = parseRecipients('"Alice, Q." <alice@example.com>')
+    expect(r.recipients[0]).toEqual({
+      email: 'alice@example.com',
+      name: 'Alice, Q.',
+    })
+  })
+
+  it('accepts comma and semicolon separators in addition to newlines', () => {
+    const r = parseRecipients('a@x.com, b@x.com; c@x.com')
+    expect(r.recipients.map((p) => p.email)).toEqual([
+      'a@x.com',
+      'b@x.com',
+      'c@x.com',
+    ])
+  })
+
+  it('dedupes case-insensitively, preserving first-seen casing', () => {
+    const r = parseRecipients('Alice@Example.com\nalice@example.com')
+    expect(r.recipients).toHaveLength(1)
+    expect(r.recipients[0].email).toBe('Alice@Example.com')
+  })
+
+  it('rejects malformed addresses and lists them in invalid', () => {
+    const r = parseRecipients('not-an-email\nbob@example.com\n@nope')
+    expect(r.recipients.map((p) => p.email)).toEqual(['bob@example.com'])
+    expect(r.invalid).toEqual(['not-an-email', '@nope'])
+  })
+
+  it('ignores blank lines and surrounding whitespace', () => {
+    const r = parseRecipients('\n  alice@example.com  \n\n  bob@example.com\n')
+    expect(r.recipients).toHaveLength(2)
+  })
+
+  it('returns empty result for empty input', () => {
+    expect(parseRecipients('')).toEqual({ recipients: [], invalid: [] })
+    expect(parseRecipients('   \n\n  ')).toEqual({ recipients: [], invalid: [] })
+  })
+
+  it('omits the name key entirely when angle name is empty', () => {
+    const r = parseRecipients('   <alice@example.com>')
+    expect(r.recipients[0]).toEqual({ email: 'alice@example.com' })
+    expect('name' in r.recipients[0]).toBe(false)
+  })
+})


### PR DESCRIPTION
The /dashboard/campaigns/new page rendered a form with no submit button, no recipient input, and no email account picker — clicking through did nothing. The /api/campaigns POST already worked, the UI just never called it.

- Add recipient textarea (newline, comma, or semicolon separated; optional `Name <email>` form). Shows live valid/invalid counts.
- Add email account select populated from /api/email-accounts, filtered to status=connected. Auto-selects when there is exactly one connected account.
- Submit button posts the parsed payload to /api/campaigns; shows inline success or error.
- Extract parser to src/lib/recipientParser.ts so it is testable without mounting React. 9 vitest specs cover bare/angle formats, quoted-name comma handling, comma/semicolon/newline separators, case-insensitive dedupe, malformed rejection, and empty input.

No changes to API routes, schema, or queue/send pipeline. Builds on top of HIR-94 PR #8 (gmail connect flow) but is independent at the code level.