### PR TITLE
hir-106: add starter cold-email template library

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,79 @@
 
 
 
+# Templates
+
+Starter cold-email templates live in [`/templates`](./templates). Each file is
+a single ICP × purpose combination — pick the closest match, swap the variables,
+adapt the body in your own voice. Bodies are 80–140 words, plain text, no
+buzzword soup.
+
+The current set:
+
+| File | ICP | Purpose |
+| --- | --- | --- |
+| `devtools-cold-intro.json` | Engineering manager / staff engineer | Book a 15-min product demo |
+| `b2b-saas-cold-intro.json` | Head of RevOps / Sales Ops | Land a 20-min discovery call |
+| `agency-services-pitch.json` | Founder / marketing lead | Open a paid-engagement conversation |
+| `recruiter-candidate-outreach.json` | Senior / staff engineer | Book an exploratory call |
+| `fundraising-warm-intro.json` | Friend / advisor (forwardable to investor) | Get a warm intro to a specific VC |
+| `partnership-pitch.json` | Partnerships lead at adjacent product | Explore co-marketing or integration |
+| `customer-research-interview.json` | Anyone in your ICP | Book a 20-min discovery interview |
+| `lapsed-lead-revive.json` | Prospect silent 30+ days | Re-open the conversation |
+
+## Template JSON shape
+
+```json
+{
+  "id": "devtools-cold-intro",
+  "name": "Devtools cold intro",
+  "icp": "Engineering manager / staff engineer at series A–C startups",
+  "purpose": "Book a 15-min product demo",
+  "subjectLines": ["...", "..."],
+  "body": "Hi {{firstName}}, ...",
+  "variables": [
+    {"key": "firstName", "required": true},
+    {"key": "company", "required": true},
+    {"key": "specificObservation", "required": false, "note": "Something specific you noticed about their product or recent post."}
+  ],
+  "notes": "Why this template works, when to use it, what to swap.",
+  "license": "MIT"
+}
+```
+
+Fields:
+
+- `id` — kebab-case identifier; matches the filename.
+- `name` — human-readable label for pickers.
+- `icp` — who this is aimed at.
+- `purpose` — the single outcome the email is trying to produce.
+- `subjectLines` — 2–3 variants. Test before scaling.
+- `body` — plain text, `{{var}}` placeholders, no HTML.
+- `variables` — every placeholder used in `subjectLines` or `body`. `required: true` means the email shouldn't go without it; `required: false` means it's worth using if you have it. Use the optional `note` field to coach senders on what makes a good value.
+- `notes` — when to use, when not to, what tends to break.
+- `license` — usage license. All starters ship as MIT.
+
+## How to use a template
+
+Today, templates are content-only. Pick one, copy the `body` and one of the
+`subjectLines` into the compose UI, and substitute your variables by hand.
+
+Wiring `templates/` directly into the compose UI as a picker is a follow-up —
+see the parent plan in HIR-105, or open an issue if you want it sooner.
+
+## Contributing a template
+
+PRs welcome. Keep new templates aligned with the conventions:
+
+- One ICP × purpose per file.
+- 80–140 word body, plain text, no jargon.
+- 2–3 subject line variants.
+- Document every variable, including a `note` for non-obvious ones.
+- `notes` should explain *why* the template works and what to watch out for.
+- All starters in this repo are MIT-licensed.
+
+
+
 # Move the needle TO-DO list:
 
 - [x] Templates for popular email needs i.e "onboarding for SaaS" — see `/templates`

--- a/templates/agency-services-pitch.json
+++ b/templates/agency-services-pitch.json
@@ -1,0 +1,29 @@
+{
+  "id": "agency-services-pitch",
+  "name": "Agency reaching out to founders",
+  "icp": "Founder or marketing lead at a seed–series B startup",
+  "purpose": "Open a conversation about a paid engagement",
+  "subjectLines": [
+    "{{specificObservation}} — one idea",
+    "{{company}}'s {{channelOrChannel}} — quick thought",
+    "Not a pitch, just one observation about {{company}}"
+  ],
+  "body": "Hi {{firstName}},\n\n{{specificObservation}}. Spent ten minutes looking through {{company}}'s {{channelOrChannel}} this morning and one thing jumped out: {{specificFinding}}.\n\nWe run a small {{agencyType}} agency — five people, ex-{{founderBackground}}. Most of our clients are at the same stage as {{company}}. Recent example: helped {{customerExampleA}} take {{metric}} from {{beforeMetric}} to {{afterMetric}} over {{timeframe}}.\n\nNo deck, no discovery call upfront. If it's useful, I'll send a free 2-page write-up of what I'd actually change about {{specificFinding}}. If you want to talk after that, great. If not, no follow-up.\n\nFair?\n\n{{senderFirstName}}",
+  "variables": [
+    {"key": "firstName", "required": true},
+    {"key": "company", "required": true},
+    {"key": "specificObservation", "required": true, "note": "Open with something genuine — a recent launch, a hiring move, a product decision."},
+    {"key": "channelOrChannel", "required": true, "note": "The actual channel you reviewed. e.g. 'landing page', 'paid search ads', 'cold email sequence'."},
+    {"key": "specificFinding", "required": true, "note": "One concrete observation. Not 'your funnel could be tighter.' Try 'your pricing page hides the ICP-specific copy below the fold.'"},
+    {"key": "agencyType", "required": true, "note": "e.g. 'growth', 'content', 'paid acquisition'."},
+    {"key": "founderBackground", "required": false, "note": "Where the team came from. e.g. 'Stripe + HubSpot'. Skip if not credible."},
+    {"key": "customerExampleA", "required": false},
+    {"key": "metric", "required": false},
+    {"key": "beforeMetric", "required": false},
+    {"key": "afterMetric", "required": false},
+    {"key": "timeframe", "required": false},
+    {"key": "senderFirstName", "required": true}
+  ],
+  "notes": "Founders get pitched constantly by agencies and the bar is high. The differentiator is offering free, specific work upfront — the 2-page write-up. Only use this if you'll actually deliver one. The 'no follow-up' line is a contract; honor it. If you can't fill in customerExampleA truthfully, delete that sentence and lean harder on the specific finding.",
+  "license": "MIT"
+}

--- a/templates/b2b-saas-cold-intro.json
+++ b/templates/b2b-saas-cold-intro.json
@@ -1,0 +1,28 @@
+{
+  "id": "b2b-saas-cold-intro",
+  "name": "B2B SaaS cold intro to ops/RevOps",
+  "icp": "Head of RevOps, Sales Ops, or BizOps at a 50–500-person B2B SaaS",
+  "purpose": "Land a 20-min call to walk through the pain and see if the product fits",
+  "subjectLines": [
+    "{{company}} + {{painPoint}}",
+    "Quick one for the {{company}} ops team",
+    "Saw the {{specificObservation}} — curious how it's going"
+  ],
+  "body": "Hi {{firstName}},\n\nNoticed {{specificObservation}}. Usually when a team gets to that stage, {{painPoint}} starts eating an unreasonable amount of the ops team's week.\n\nWe built {{productName}} to fix that one specific thing. {{customerExampleA}} cut their {{metric}} from {{beforeMetric}} to {{afterMetric}} in {{timeframe}}, with no extra headcount.\n\nNot trying to replace your stack. It plugs into {{integrationStack}} and runs alongside what you already have.\n\nIf the timing's right, I can show you the {{customerExampleA}} setup in 20 minutes — happy to send the recording instead if a live call is too much.\n\nWorth a conversation?\n\n{{senderFirstName}}",
+  "variables": [
+    {"key": "firstName", "required": true},
+    {"key": "company", "required": true},
+    {"key": "specificObservation", "required": true, "note": "A signal: hiring a RevOps role, recent funding, a podcast appearance, a tool migration. Avoid generic 'congrats on the growth.'"},
+    {"key": "painPoint", "required": true, "note": "The pain in their language. e.g. 'lead routing latency', 'pipeline hygiene', 'attribution gaps'."},
+    {"key": "productName", "required": true},
+    {"key": "customerExampleA", "required": false, "note": "Use only if you have permission. Otherwise drop the case-study sentence and rewrite around the product."},
+    {"key": "metric", "required": false, "note": "The metric that moved. e.g. 'lead-to-meeting conversion', 'time-to-first-touch'."},
+    {"key": "beforeMetric", "required": false},
+    {"key": "afterMetric", "required": false},
+    {"key": "timeframe", "required": false},
+    {"key": "integrationStack", "required": true, "note": "The 1–2 tools they almost certainly already use. e.g. 'Salesforce + Outreach'."},
+    {"key": "senderFirstName", "required": true}
+  ],
+  "notes": "RevOps people are skeptical of cold email by trade — they read these for a living. The win here is being concrete: name the pain, name the metric, name the tools you integrate with, and offer a recording instead of a call. Drop the case-study paragraph entirely if you can't substantiate it; a vague claim is worse than no claim.",
+  "license": "MIT"
+}

--- a/templates/customer-research-interview.json
+++ b/templates/customer-research-interview.json
@@ -1,0 +1,24 @@
+{
+  "id": "customer-research-interview",
+  "name": "Customer research / discovery interview ask",
+  "icp": "Person in your target ICP — could be a current user, a churned user, or a non-user who fits the profile",
+  "purpose": "Book a 20-minute discovery call",
+  "subjectLines": [
+    "20 minutes on {{topicArea}}?",
+    "Quick research request — {{topicArea}}",
+    "Picking your brain on {{topicArea}}"
+  ],
+  "body": "Hi {{firstName}},\n\nShort one. We're doing customer research at {{yourCompany}} on how {{icpDescription}} actually handle {{topicArea}} day-to-day. You came up because of {{specificReason}}.\n\nI'm not selling anything on this call. I'm trying to understand:\n- How you currently handle {{topicArea}}\n- Where the process breaks or feels heavy\n- What 'good' would look like for you\n\n20 minutes, video off if you'd rather. Happy to share what we learn from the full set of interviews — most people we talk to find the cross-cut more useful than their individual call.\n\nAs a thank-you, {{thankYouOffer}}.\n\nIf you're up for it, here's my calendar: {{calendarLink}}. Or just reply with two times that work and I'll send an invite.\n\n{{senderFirstName}}",
+  "variables": [
+    {"key": "firstName", "required": true},
+    {"key": "yourCompany", "required": true},
+    {"key": "icpDescription", "required": true, "note": "How you'd describe their role/situation. e.g. 'engineering managers at series A startups'."},
+    {"key": "topicArea", "required": true, "note": "The narrow topic. e.g. 'sprint planning', 'incident response', 'pipeline forecasting'."},
+    {"key": "specificReason", "required": true, "note": "Why this person specifically. e.g. 'a referral from {{referrerName}}' or 'your recent post on X.'"},
+    {"key": "thankYouOffer", "required": false, "note": "e.g. 'a $50 Amazon gift card', 'a copy of the full research summary', 'a free year of {{productName}}.' Drop the line if you don't have one."},
+    {"key": "calendarLink", "required": true},
+    {"key": "senderFirstName", "required": true}
+  ],
+  "notes": "The single biggest mistake in research outreach is making it sound like a sales call. Be explicit that it isn't. The promise to share what you learn is the most underrated incentive — it works better than gift cards on senior people. The bullet list of what you'll ask is reassuring; vague 'pick your brain' asks get archived.",
+  "license": "MIT"
+}

--- a/templates/devtools-cold-intro.json
+++ b/templates/devtools-cold-intro.json
@@ -1,0 +1,25 @@
+{
+  "id": "devtools-cold-intro",
+  "name": "Devtools cold intro",
+  "icp": "Engineering manager / staff engineer at series A–C startups",
+  "purpose": "Book a 15-min product demo",
+  "subjectLines": [
+    "{{specificObservation}} — quick question",
+    "How {{company}} handles {{painPoint}}",
+    "15 min on {{painPoint}} at {{company}}?"
+  ],
+  "body": "Hi {{firstName}},\n\nI saw {{specificObservation}} — that resonated because most teams I talk to are dealing with {{painPoint}} around the same growth stage.\n\nI'm building {{productName}}. It's a {{oneLineDescription}}. Engineering teams at {{customerExampleA}} and {{customerExampleB}} use it to cut {{painPoint}} cycles roughly in half.\n\nNot trying to pitch a platform. If it's relevant, I can share a 5-minute Loom of how a team your size set it up — no demo call needed. If you'd rather just try it, the docs are public and there's a free tier with no card.\n\nWorth a look?\n\n{{senderFirstName}}",
+  "variables": [
+    {"key": "firstName", "required": true},
+    {"key": "company", "required": true},
+    {"key": "specificObservation", "required": true, "note": "Something concrete: a recent post, a job listing, a talk, a repo. Avoid 'I saw your company is growing fast.'"},
+    {"key": "painPoint", "required": true, "note": "The narrow problem your product solves, in their words. e.g. 'flaky CI', 'slow PR reviews'."},
+    {"key": "productName", "required": true},
+    {"key": "oneLineDescription", "required": true, "note": "One sentence, no jargon. e.g. 'CI cache layer that cuts test times by skipping unchanged files.'"},
+    {"key": "customerExampleA", "required": false, "note": "A recognizable customer name if you have permission to share."},
+    {"key": "customerExampleB", "required": false},
+    {"key": "senderFirstName", "required": true}
+  ],
+  "notes": "Works because it leads with a specific observation, names the pain in their language, and removes the friction of a demo call by offering a Loom. Skip the customer logos line if you don't have permission to use names. The free-tier mention only works if you actually have a free tier; otherwise drop that sentence.",
+  "license": "MIT"
+}

--- a/templates/fundraising-warm-intro.json
+++ b/templates/fundraising-warm-intro.json
@@ -1,0 +1,31 @@
+{
+  "id": "fundraising-warm-intro",
+  "name": "Founder asking for an intro to an investor",
+  "icp": "Friend, advisor, or prior coworker who knows the target investor personally",
+  "purpose": "Get a forwardable intro to a specific investor",
+  "subjectLines": [
+    "Quick intro ask — {{investorName}}",
+    "Would you mind forwarding this to {{investorFirstName}}?",
+    "{{companyName}} fundraise — small ask"
+  ],
+  "body": "Hey {{firstName}},\n\nQuick ask. We're raising a {{roundType}} for {{companyName}} and {{investorName}} at {{investorFirm}} is at the top of our list — they led {{relevantPortfolioCo}}, which is the closest analogue to what we're building.\n\nWould you be open to forwarding the note below? Totally fine to say no or to add caveats.\n\n---\n\nHi {{investorFirstName}},\n\n{{introducerFirstName}} suggested I reach out. I'm {{senderFirstName}}, founder of {{companyName}}. We're building {{oneLineDescription}}.\n\nQuick traction snapshot: {{tractionMetric1}} and {{tractionMetric2}}. We're raising a {{roundSize}} {{roundType}} to {{useOfFunds}}.\n\nGiven your work with {{relevantPortfolioCo}}, I think you'd see the angle quickly. Open to a 20-min call in the next two weeks?\n\n{{senderFirstName}}\n{{deckLinkOrNote}}\n\n---\n\nThanks for considering it, {{firstName}} — and totally no pressure either way.\n\n{{senderFirstName}}",
+  "variables": [
+    {"key": "firstName", "required": true, "note": "The introducer's first name."},
+    {"key": "companyName", "required": true},
+    {"key": "roundType", "required": true, "note": "e.g. 'pre-seed', 'seed', 'Series A bridge'."},
+    {"key": "roundSize", "required": true, "note": "e.g. '$2M', '$8M'."},
+    {"key": "investorName", "required": true, "note": "Full name."},
+    {"key": "investorFirstName", "required": true},
+    {"key": "investorFirm", "required": true},
+    {"key": "relevantPortfolioCo", "required": true, "note": "A specific portfolio company that maps to your space. Be honest about the analogue."},
+    {"key": "introducerFirstName", "required": true, "note": "Same as firstName, repeated for the forwarded note."},
+    {"key": "senderFirstName", "required": true},
+    {"key": "oneLineDescription", "required": true, "note": "Plain English. No 'AI-powered platform.' One sentence."},
+    {"key": "tractionMetric1", "required": true, "note": "Real numbers. e.g. '$22k MRR, 18% MoM growth'."},
+    {"key": "tractionMetric2", "required": true},
+    {"key": "useOfFunds", "required": true, "note": "What the money buys. e.g. 'extend runway 18 months and hire two engineers'."},
+    {"key": "deckLinkOrNote", "required": false, "note": "Either a link to a 5-slide deck, or 'happy to send the deck after the call.'"}
+  ],
+  "notes": "The forwardable note is the whole point — it has to stand on its own without the original wrapper. Investors evaluate the forwarded note in 30 seconds. The traction numbers should be specific and recent (last 30 days). Always give the introducer an out — don't make them feel obligated. If the investor doesn't actually map to your space, this template is a waste of a warm contact.",
+  "license": "MIT"
+}

--- a/templates/lapsed-lead-revive.json
+++ b/templates/lapsed-lead-revive.json
@@ -1,0 +1,23 @@
+{
+  "id": "lapsed-lead-revive",
+  "name": "Re-engaging a prospect who went silent 30+ days ago",
+  "icp": "A prospect who replied at least once and then went quiet 30+ days ago",
+  "purpose": "Re-open the conversation without sounding desperate",
+  "subjectLines": [
+    "Should I close the loop on this?",
+    "{{painPoint}} — still on your radar?",
+    "Quick check-in, {{firstName}}"
+  ],
+  "body": "Hi {{firstName}},\n\nLast time we talked you mentioned {{quotedPainOrContext}}. I assumed it got deprioritized — totally understand, things shift.\n\nTwo reasons I'm following up now:\n\n1. {{newReason}} — felt relevant given what you said.\n2. I'd rather close the loop than leave it hanging. If this isn't a {{currentQuarter}} priority, just tell me and I'll stop following up.\n\nIf it is back on the radar, the change since we last talked: {{productOrCompanyUpdate}}.\n\nWhich is it — paused, dead, or still interesting?\n\n{{senderFirstName}}",
+  "variables": [
+    {"key": "firstName", "required": true},
+    {"key": "painPoint", "required": false, "note": "Used in one of the subject lines only. The pain in their language from the original conversation. e.g. 'lead routing latency'. Pick a different subject if you don't have one."},
+    {"key": "quotedPainOrContext", "required": true, "note": "Quote them as closely as you can. e.g. 'you wanted to revisit after the Q1 board meeting' or 'you mentioned your team was buried in a migration.' Specificity proves you remember the conversation."},
+    {"key": "newReason", "required": true, "note": "A genuine new reason. e.g. 'we just shipped the Salesforce integration you asked about', 'we cut pricing for teams under 50.' If there's no new reason, this template doesn't work — wait until there is one."},
+    {"key": "currentQuarter", "required": true, "note": "e.g. 'Q2', 'this quarter', 'before the half'."},
+    {"key": "productOrCompanyUpdate", "required": false, "note": "Optional second hook. e.g. 'we hired a CS lead from notableCompany.' Skip if redundant with newReason."},
+    {"key": "senderFirstName", "required": true}
+  ],
+  "notes": "The 'paused, dead, or still interesting?' close is the workhorse of this template — it gives the prospect three legitimate options instead of guilting them into a yes. The quoted pain is what makes it land; if you can't remember what they said, go read the thread before sending. Don't send this template more than once per lapsed lead — if they don't respond, mark them dead and move on.",
+  "license": "MIT"
+}

--- a/templates/partnership-pitch.json
+++ b/templates/partnership-pitch.json
@@ -1,0 +1,26 @@
+{
+  "id": "partnership-pitch",
+  "name": "Co-marketing or integration partnership pitch",
+  "icp": "Partnerships lead, head of marketing, or founder at an adjacent product",
+  "purpose": "Open a conversation about a co-marketing or integration partnership",
+  "subjectLines": [
+    "{{yourCompany}} + {{theirCompany}} — partnership idea",
+    "Quick partnership idea for {{theirCompany}}",
+    "Customers asking about {{theirCompany}} on our side"
+  ],
+  "body": "Hi {{firstName}},\n\n{{specificObservation}}. We've had a handful of customers ask if we integrate with {{theirCompany}} — enough that I thought I'd reach out directly.\n\nFor context: {{yourCompany}} is {{oneLineDescription}}. Our overlap is {{overlapDescription}} — about {{overlapEstimate}} of our customer base also uses {{theirCompany}} or something like it.\n\nTwo concrete things I'd be interested in exploring, in order of effort:\n\n1. {{lowEffortIdea}} — could ship in a week.\n2. {{higherEffortIdea}} — bigger lift, but probably the more interesting one for both sides.\n\nNo deck, no contract — just a 25-min call to see if any of this is worth pursuing. Worst case, you get a sense of what our customers are asking for.\n\nWho's the right person to talk to if it's not you?\n\n{{senderFirstName}}",
+  "variables": [
+    {"key": "firstName", "required": true},
+    {"key": "yourCompany", "required": true},
+    {"key": "theirCompany", "required": true},
+    {"key": "specificObservation", "required": true, "note": "Open with a real signal. e.g. 'Saw your launch on Product Hunt last week.'"},
+    {"key": "oneLineDescription", "required": true, "note": "What you do, in one sentence, no marketing language."},
+    {"key": "overlapDescription", "required": true, "note": "Where the customer bases meet. e.g. 'mid-market SaaS teams running outbound sales.'"},
+    {"key": "overlapEstimate", "required": false, "note": "A number you can defend. e.g. '40%'. If you don't actually know, drop this sentence."},
+    {"key": "lowEffortIdea", "required": true, "note": "Something concrete that takes <1 week. e.g. 'a joint webinar' or 'a product comparison page that cross-links.'"},
+    {"key": "higherEffortIdea", "required": true, "note": "Something concrete that takes 1–3 months. e.g. 'a native integration that lets our users export segments to your tool.'"},
+    {"key": "senderFirstName", "required": true}
+  ],
+  "notes": "Partnership pitches die in inboxes when they're vague about what's being proposed. The two-tier ask (low-effort + higher-effort) gives the recipient a way to say yes to something small. The 'who's the right person' close is intentional — partnerships people often forward these.",
+  "license": "MIT"
+}

--- a/templates/recruiter-candidate-outreach.json
+++ b/templates/recruiter-candidate-outreach.json
@@ -1,0 +1,28 @@
+{
+  "id": "recruiter-candidate-outreach",
+  "name": "Recruiter to passive engineering candidate",
+  "icp": "Senior or staff engineer who is not actively job-searching",
+  "purpose": "Get a 20-minute exploratory call on the calendar",
+  "subjectLines": [
+    "{{specificObservation}} — quick question",
+    "{{roleTitle}} role at {{company}} — worth a look?",
+    "Not the usual recruiter email"
+  ],
+  "body": "Hi {{firstName}},\n\nFair warning: this is a recruiter email. I'll keep it short.\n\nI saw {{specificObservation}} and your background in {{technicalArea}} lined up almost exactly with what {{company}} is hiring for. The role is {{roleTitle}}, reporting to {{managerName}} ({{managerBackground}}). Comp is {{compRange}}, fully remote, {{additionalDetail}}.\n\nThe interesting parts, if you're curious: {{interestingPart1}} and {{interestingPart2}}.\n\nI know you're probably happy where you are — most of the people I want to talk to are. If even 10% of the above sounds interesting, I'm happy to send a 1-page write-up so you can decide without a call. If not, I won't follow up.\n\nWorth a look?\n\n{{senderFirstName}}",
+  "variables": [
+    {"key": "firstName", "required": true},
+    {"key": "specificObservation", "required": true, "note": "Something from their GitHub, a talk, a blog post. Not 'I saw your impressive profile.'"},
+    {"key": "company", "required": true},
+    {"key": "technicalArea", "required": true, "note": "The narrow area of overlap. e.g. 'distributed systems on Go', 'frontend perf at scale'."},
+    {"key": "roleTitle", "required": true},
+    {"key": "managerName", "required": true},
+    {"key": "managerBackground", "required": true, "note": "One line about who the manager is. e.g. 'ex-Stripe payments lead'. Candidates care about who they'll work for."},
+    {"key": "compRange", "required": true, "note": "Be transparent. e.g. '$280–340k base + 0.1–0.3% equity'. Vague comp ranges signal vague companies."},
+    {"key": "additionalDetail", "required": false, "note": "e.g. 'pre-IPO', 'post-Series C', 'profitable, no investor pressure'."},
+    {"key": "interestingPart1", "required": true, "note": "An actual technical or business hook. e.g. 'rebuilding the indexing pipeline from scratch.'"},
+    {"key": "interestingPart2", "required": true},
+    {"key": "senderFirstName", "required": true}
+  ],
+  "notes": "Senior engineers archive 95% of recruiter mail in <3 seconds. The only reason this one survives is the comp range, the manager name, and a real technical hook. If you can't share comp publicly, this template won't work — use a different approach. The 'I won't follow up' promise is a real commitment; don't bait-and-switch.",
+  "license": "MIT"
+}


### PR DESCRIPTION
## Summary

Adds a `templates/` directory with **8 starter cold-email templates** so first-time Coldflow users have working templates instead of a blank textarea.

This is the first increment under the parent plan in HIR-105 — scope is intentionally tight: content-only, no compose-UI wiring.

Closes HIR-106. Parent: HIR-105.

## What's in the box

| File | ICP | Purpose |
| --- | --- | --- |
| `devtools-cold-intro.json` | Eng manager / staff engineer | Book a 15-min product demo |
| `b2b-saas-cold-intro.json` | RevOps / Sales Ops lead | Land a 20-min discovery call |
| `agency-services-pitch.json` | Founder / marketing lead | Open a paid-engagement conversation |
| `recruiter-candidate-outreach.json` | Senior / staff engineer | Book an exploratory call |
| `fundraising-warm-intro.json` | Friend / advisor (forwardable to investor) | Get a warm intro to a specific VC |
| `partnership-pitch.json` | Partnerships lead at adjacent product | Explore co-marketing or integration |
| `customer-research-interview.json` | Anyone in your ICP | Book a 20-min discovery interview |
| `lapsed-lead-revive.json` | Prospect silent 30+ days | Re-open the conversation |

Every template:
- 80–140 word body, plain text, `{{var}}` placeholders, no buzzword soup
- 2–3 subject line variants
- Documented variables with `note` fields coaching senders on what makes a good value
- `notes` block explaining why the template works and what to watch out for
- MIT-licensed

## README update

New `## Templates` section that:
- Lists the current set
- Documents the JSON shape and every field
- Explains how to use a template today (paste into compose, swap variables by hand)
- Sets contributing conventions for future templates

## Out of scope (deliberate)

- **Wiring `templates/` into the compose UI as a picker** — content-only for this PR. Follow-up tracked under HIR-105.
- AI personalization (Tier 2 increment in the parent plan).
- Adding more than 8 templates.

## Test plan

- [x] All 8 JSON files parse with `json.load`
- [x] Every `{{var}}` referenced in `body` / `subjectLines` is declared in `variables` (and vice versa — no orphan declarations)
- [x] All bodies between 80–140 words
- [x] All `id` fields match filenames
- [x] All required keys present (`id`, `name`, `icp`, `purpose`, `subjectLines`, `body`, `variables`, `notes`, `license`)
- [x] No changes outside `templates/` and `README.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)