### PR TITLE
hir-94: actually reschedule queue entries when an account is over quota

### DIFF
--- a/libs/db/src/queries/emailQueue.ts
+++ b/libs/db/src/queries/emailQueue.ts
@@ -84,6 +84,40 @@ export const updateQueueStatus = async (
 };
 
 /**
+ * Reschedule a pending queue entry for a future send time. Used by the queue
+ * processor when an account is over its daily quota — without bumping
+ * `scheduledFor`, the entry would be picked again on the next batch
+ * iteration and immediately re-skipped.
+ *
+ * Always keeps the entry in `pending` status (only the time and optional
+ * error message change). `attemptCount` is intentionally NOT incremented
+ * because no send was actually attempted.
+ */
+export const rescheduleQueueEntry = async (
+  id: string,
+  newScheduledFor: Date,
+  errorMessage?: string | null
+): Promise<EmailQueue | null> => {
+  const updateData: Record<string, unknown> = {
+    status: 'pending' as const,
+    scheduledFor: newScheduledFor,
+    updatedAt: new Date(),
+  };
+
+  if (errorMessage !== undefined) {
+    updateData.errorMessage = errorMessage;
+  }
+
+  const results = await db
+    .update(emailQueue)
+    .set(updateData)
+    .where(eq(emailQueue.id, id))
+    .returning();
+
+  return results[0] || null;
+};
+
+/**
  * Increment attempt count for a queue entry
  */
 export const incrementAttemptCount = async (id: string): Promise<EmailQueue | null> => {

--- a/src/lib/emailQueueProcessor.ts
+++ b/src/lib/emailQueueProcessor.ts
@@ -1,6 +1,7 @@
 import {
   getNextPendingEmails,
   updateQueueStatus,
+  rescheduleQueueEntry,
   incrementAttemptCount,
   createEmailEvent,
   incrementCampaignStat,
@@ -8,6 +9,7 @@ import {
   isEmailUnsubscribed,
 } from '@coldflow/db';
 import { sendEmail, hasAvailableQuota } from './gmailService';
+import { computeQuotaRescheduleAt } from './queueScheduling';
 import { nanoid } from 'nanoid';
 
 /**
@@ -84,20 +86,24 @@ export async function processEmailQueue(batchSize: number = 10): Promise<Process
         const hasQuota = await hasAvailableQuota(queueEntry.emailAccountId);
         if (!hasQuota) {
           const account = await getEmailAccountById(queueEntry.emailAccountId);
-          const quotaResetAt = account?.quotaResetAt ? new Date(account.quotaResetAt) : null;
+          const quotaResetAt = account?.quotaResetAt
+            ? new Date(account.quotaResetAt)
+            : null;
 
-          if (quotaResetAt && quotaResetAt > now) {
-            // Reschedule for quota reset time
-            await updateQueueStatus(
-              queueEntry.id,
-              'pending', // Keep as pending
-              null,
-              'Quota exceeded - rescheduled'
-            );
-            result.skipped++;
-            console.log(`Email ${queueEntry.id} skipped - quota exceeded, rescheduled for ${quotaResetAt}`);
-            continue;
-          }
+          // Always push the entry's `scheduledFor` forward — without that,
+          // `getNextPendingEmails` (which filters `scheduledFor <= now`)
+          // would re-pick this entry on every batch and we'd spin.
+          const nextAttempt = computeQuotaRescheduleAt(quotaResetAt, now);
+          await rescheduleQueueEntry(
+            queueEntry.id,
+            nextAttempt,
+            'Quota exceeded - rescheduled'
+          );
+          result.skipped++;
+          console.log(
+            `Email ${queueEntry.id} skipped - quota exceeded, rescheduled for ${nextAttempt.toISOString()}`
+          );
+          continue;
         }
 
         // Update status to processing

--- a/src/lib/queueScheduling.ts
+++ b/src/lib/queueScheduling.ts
@@ -1,0 +1,45 @@
+/**
+ * Pure scheduling helpers for the email queue processor.
+ *
+ * Kept here (and not in `emailQueueProcessor.ts`) so the decision logic can
+ * be unit-tested without the DB / Gmail dependency graph. The processor
+ * imports from this module instead of inlining the math.
+ */
+
+const ONE_MINUTE_MS = 60 * 1000;
+
+/**
+ * Decide when to next try sending a queue entry whose account is over its
+ * daily quota.
+ *
+ * Inputs:
+ *   - `quotaResetAt` — the account's stored quota reset timestamp (may be
+ *      null if the account record has never been initialized, may be in
+ *      the past if a reset hasn't been written back yet).
+ *   - `now` — wall-clock time of the current processing pass.
+ *   - `minDelayMs` (optional, defaults to 1 minute) — floor on how soon we
+ *      will retry. Prevents a tight loop when `quotaResetAt` is the same
+ *      tick as `now` or already in the past.
+ *
+ * Returns a Date strictly in the future relative to `now`. Callers should
+ * write that Date back to the queue entry's `scheduledFor` so
+ * `getNextPendingEmails` (which filters by `scheduledFor <= now`) skips it
+ * until the reset time arrives.
+ */
+export function computeQuotaRescheduleAt(
+  quotaResetAt: Date | null | undefined,
+  now: Date = new Date(),
+  minDelayMs: number = ONE_MINUTE_MS
+): Date {
+  const floor = new Date(now.getTime() + Math.max(minDelayMs, 0));
+
+  if (!quotaResetAt) {
+    return floor;
+  }
+
+  if (quotaResetAt.getTime() > floor.getTime()) {
+    return new Date(quotaResetAt.getTime());
+  }
+
+  return floor;
+}

--- a/tests/int/queueScheduling.int.spec.ts
+++ b/tests/int/queueScheduling.int.spec.ts
@@ -1,0 +1,91 @@
+import { describe, expect, it } from 'vitest';
+import { computeQuotaRescheduleAt } from '@/lib/queueScheduling';
+
+describe('computeQuotaRescheduleAt', () => {
+  const now = new Date('2026-05-03T12:00:00Z');
+
+  it('uses quotaResetAt when it is far in the future', () => {
+    const reset = new Date('2026-05-04T00:00:00Z');
+    expect(computeQuotaRescheduleAt(reset, now).toISOString()).toBe(
+      reset.toISOString()
+    );
+  });
+
+  it('falls back to now+minDelay when quotaResetAt is null', () => {
+    const out = computeQuotaRescheduleAt(null, now);
+    expect(out.getTime()).toBe(now.getTime() + 60_000);
+  });
+
+  it('falls back to now+minDelay when quotaResetAt is undefined', () => {
+    const out = computeQuotaRescheduleAt(undefined, now);
+    expect(out.getTime()).toBe(now.getTime() + 60_000);
+  });
+
+  it('floors at now+minDelay when quotaResetAt is already in the past', () => {
+    const past = new Date('2026-05-03T11:00:00Z');
+    const out = computeQuotaRescheduleAt(past, now);
+    expect(out.getTime()).toBe(now.getTime() + 60_000);
+  });
+
+  it('floors at now+minDelay when quotaResetAt equals now', () => {
+    const out = computeQuotaRescheduleAt(now, now);
+    expect(out.getTime()).toBe(now.getTime() + 60_000);
+  });
+
+  it('floors at now+minDelay when quotaResetAt is sooner than the floor', () => {
+    const reset = new Date(now.getTime() + 30_000); // 30s ahead of now
+    const out = computeQuotaRescheduleAt(reset, now);
+    expect(out.getTime()).toBe(now.getTime() + 60_000);
+  });
+
+  it('uses quotaResetAt when it is just past the floor', () => {
+    const reset = new Date(now.getTime() + 90_000); // 90s ahead
+    const out = computeQuotaRescheduleAt(reset, now);
+    expect(out.toISOString()).toBe(reset.toISOString());
+  });
+
+  it('honors a custom minDelayMs', () => {
+    const out = computeQuotaRescheduleAt(null, now, 5 * 60_000);
+    expect(out.getTime()).toBe(now.getTime() + 5 * 60_000);
+  });
+
+  it('treats negative minDelayMs as zero (never schedules earlier than now)', () => {
+    const out = computeQuotaRescheduleAt(null, now, -1000);
+    expect(out.getTime()).toBe(now.getTime());
+    // Strictly: >= now. The processor still won't pick it again until the
+    // next pass, so this is intentional rather than buggy.
+    expect(out.getTime()).toBeGreaterThanOrEqual(now.getTime());
+  });
+
+  it('returns a fresh Date instance (not the input)', () => {
+    const reset = new Date('2026-05-04T00:00:00Z');
+    const out = computeQuotaRescheduleAt(reset, now);
+    expect(out).not.toBe(reset);
+    expect(out.getTime()).toBe(reset.getTime());
+  });
+
+  it('uses the system clock when `now` is omitted', () => {
+    const before = Date.now();
+    const out = computeQuotaRescheduleAt(null);
+    const after = Date.now();
+    // Output should be in [before+60_000, after+60_000].
+    expect(out.getTime()).toBeGreaterThanOrEqual(before + 60_000);
+    expect(out.getTime()).toBeLessThanOrEqual(after + 60_000);
+  });
+
+  it('never returns a Date earlier than `now` for any reset value', () => {
+    const cases: Array<Date | null | undefined> = [
+      null,
+      undefined,
+      new Date('1970-01-01T00:00:00Z'),
+      new Date('2026-05-03T11:59:59Z'),
+      new Date('2026-05-03T12:00:00Z'),
+      new Date('2026-05-03T12:00:01Z'),
+      new Date('2099-01-01T00:00:00Z'),
+    ];
+    for (const reset of cases) {
+      const out = computeQuotaRescheduleAt(reset, now);
+      expect(out.getTime()).toBeGreaterThanOrEqual(now.getTime());
+    }
+  });
+});


### PR DESCRIPTION
## Summary
The quota-exceeded branch in `processEmailQueue` claimed to "reschedule for quota reset time" but the underlying `updateQueueStatus` call only touched `status` and `errorMessage` — `scheduledFor` stayed at its original value. Since `getNextPendingEmails` filters by `scheduledFor <= now`, the same entry got re-picked on every batch, re-checked unsubscribe + quota, and re-skipped. Under sustained load with one over-quota account, the processor's entire batch fills with the same N entries every iteration and other accounts' work starves.

## Changes
- `libs/db/src/queries/emailQueue.ts`: new `rescheduleQueueEntry(id, newScheduledFor, errorMessage?)` helper. Keeps status `pending`, bumps `scheduledFor`, sets `updatedAt`. Does NOT increment `attemptCount` because no send was attempted.
- `src/lib/queueScheduling.ts` (new): pure `computeQuotaRescheduleAt(quotaResetAt, now?, minDelayMs?)`. Honors the account's stored quota reset when it's far enough out; floors at `now + minDelay` (default 1 minute) when the reset is null, in the past, equal to now, or sooner than the floor. Always returns a Date `>= now` so we never schedule backwards.
- `src/lib/emailQueueProcessor.ts`: quota-exceeded branch calls `rescheduleQueueEntry` with the computed Date. Also drops the previous "reset is in the past → fall through and try to send" path. A fresh quota window is the account row's responsibility; falling through would attempt a send against an account whose `quotaUsedToday` is still at the limit. Safer to wait for the reset to be applied.

## Tests
- `tests/int/queueScheduling.int.spec.ts` — 12 specs: future reset honored; null/undefined fallback; past-reset floor; equal-to-now floor; sub-floor reset clamped to floor; just-past-floor reset honored; custom `minDelayMs`; negative `minDelayMs` clamped to zero; fresh-Date guarantee (output is not the input reference); default-`now` omission; "output >= now" property across a parametric input set.
- All 12 new tests pass. Full `pnpm test:int`: 107/108 pass; the 1 failure is the pre-existing `api.int.spec.ts` Payload-secret issue on `main`, unrelated.
- `pnpm lint` clean for all changed files.

## Regression analysis
- The processor's other branches (sent, failed, retry, max-attempts, unsubscribed, scheduled-in-future) are untouched.
- `updateQueueStatus` is still used everywhere it was before. The new `rescheduleQueueEntry` is additive.
- Removing the "reset already in the past → try to send anyway" fall-through is a behavior change, but the previous behavior was buggy: it would attempt a Gmail send against an account whose `quotaUsedToday` had not been reset, which Gmail would reject and the entry would then count as a real failure (incrementing `attemptCount` toward the max-attempts cap). The new behavior — wait for the reset — is strictly safer.

## Test plan
- [ ] Manually exhaust a connected Gmail account's daily quota (set `dailyQuota: 1` and `quotaUsedToday: 1` in the DB).
- [ ] Create a campaign with 10 recipients on that account, plus 5 recipients on a second connected account.
- [ ] POST `/api/email-queue/process` and confirm: the 5 entries on account #2 send; the 10 entries on the over-quota account get `scheduledFor` bumped to the account's `quotaResetAt`, and the next process call no longer re-picks them.
- [ ] Manually set `quotaUsedToday: 0` and `quotaResetAt: now() + 1 hour`, set the queue entry's `scheduledFor: now() + 30 seconds`, and confirm a process call right now does not re-pick it.

## Cumulative HIR-94 progress
- ✅ [#8](https://github.com/pypesdev/coldflow/pull/8) — Gmail OAuth connect (22 specs)
- ✅ [#9](https://github.com/pypesdev/coldflow/pull/9) — Campaign create UI + recipient parser (9 specs)
- ✅ [#10](https://github.com/pypesdev/coldflow/pull/10) — RFC-correct MIME (41 specs)
- 🟡 [#13](https://github.com/pypesdev/coldflow/pull/13) — Per-recipient variables + substitution (25 new specs)
- 🟡 This PR — Queue quota-rescheduling (12 specs)
- ⏭ Next: CSV recipient upload; daily quota reset job.

🤖 Generated with [Claude Code](https://claude.com/claude-code)