### PR TITLE
hir-94: campaigns list + detail pages, post-create redirect

### DIFF
--- a/src/app/(frontend)/dashboard/campaigns/[id]/page.tsx
+++ b/src/app/(frontend)/dashboard/campaigns/[id]/page.tsx
@@ -1,0 +1,215 @@
+'use client'
+
+import { use, useEffect, useState } from 'react'
+import Link from 'next/link'
+import { useRouter } from 'next/navigation'
+import { Button } from '@/components/ui/button'
+import {
+  describeCampaignStatus,
+  formatCampaignProgress,
+} from '@/lib/campaignStatus'
+
+type CampaignDetail = {
+  id: string
+  name: string
+  status: string
+  totalRecipients: number
+  sentCount: number
+  openCount: number
+  clickCount: number
+  replyCount: number
+  bounceCount: number
+  unsubscribeCount: number
+  createdAt: string
+  updatedAt: string
+  queueStats?: {
+    pending?: number
+    sent?: number
+    failed?: number
+    bounced?: number
+  }
+}
+
+type LoadState =
+  | { kind: 'loading' }
+  | { kind: 'ready'; campaign: CampaignDetail }
+  | { kind: 'error'; status?: number; message: string }
+
+export default function CampaignDetailPage({
+  params,
+}: {
+  params: Promise<{ id: string }>
+}) {
+  const { id } = use(params)
+  const router = useRouter()
+  const [state, setState] = useState<LoadState>({ kind: 'loading' })
+  const [deleting, setDeleting] = useState(false)
+
+  useEffect(() => {
+    let cancelled = false
+    fetch(`/api/campaigns/${id}`)
+      .then(async (res) => {
+        const data = await res.json().catch(() => ({}))
+        if (!res.ok || !data?.success) {
+          const msg = data?.error || `Failed (${res.status})`
+          throw Object.assign(new Error(msg), { status: res.status })
+        }
+        return data.campaign as CampaignDetail
+      })
+      .then((campaign) => {
+        if (!cancelled) setState({ kind: 'ready', campaign })
+      })
+      .catch((err) => {
+        if (cancelled) return
+        setState({
+          kind: 'error',
+          status: err?.status,
+          message: err instanceof Error ? err.message : String(err),
+        })
+      })
+    return () => {
+      cancelled = true
+    }
+  }, [id])
+
+  const handleDelete = async () => {
+    if (state.kind !== 'ready') return
+    if (!confirm(`Delete "${state.campaign.name}" and all its queue entries?`)) {
+      return
+    }
+    setDeleting(true)
+    try {
+      const res = await fetch(`/api/campaigns/${id}`, { method: 'DELETE' })
+      const data = await res.json().catch(() => ({}))
+      if (!res.ok || !data?.success) {
+        throw new Error(data?.error || `Failed (${res.status})`)
+      }
+      router.push('/dashboard/campaigns')
+    } catch (err) {
+      alert(err instanceof Error ? err.message : String(err))
+      setDeleting(false)
+    }
+  }
+
+  return (
+    <div className="p-8">
+      <div className="max-w-3xl mx-auto">
+        <nav className="mb-4 text-sm text-muted-foreground">
+          <Link href="/dashboard/campaigns" className="underline">
+            Campaigns
+          </Link>{' '}
+          / <span>{state.kind === 'ready' ? state.campaign.name : id}</span>
+        </nav>
+
+        {state.kind === 'loading' && (
+          <p className="text-sm text-muted-foreground">Loading campaign…</p>
+        )}
+
+        {state.kind === 'error' && (
+          <div className="rounded border bg-red-50 p-4">
+            <p className="text-sm text-red-600">{state.message}</p>
+            {state.status === 404 && (
+              <p className="text-sm text-muted-foreground mt-2">
+                Campaign may have been deleted.{' '}
+                <Link href="/dashboard/campaigns" className="underline">
+                  Back to list
+                </Link>
+                .
+              </p>
+            )}
+          </div>
+        )}
+
+        {state.kind === 'ready' && (
+          <CampaignDetailBody
+            campaign={state.campaign}
+            deleting={deleting}
+            onDelete={handleDelete}
+          />
+        )}
+      </div>
+    </div>
+  )
+}
+
+function CampaignDetailBody({
+  campaign,
+  deleting,
+  onDelete,
+}: {
+  campaign: CampaignDetail
+  deleting: boolean
+  onDelete: () => void
+}) {
+  const badge = describeCampaignStatus(campaign.status)
+  return (
+    <>
+      <header className="mb-6 flex items-start justify-between gap-4">
+        <div>
+          <h1 className="text-2xl font-bold mb-1">{campaign.name}</h1>
+          <p className="text-sm text-muted-foreground">
+            Created {new Date(campaign.createdAt).toLocaleString()} · Updated{' '}
+            {new Date(campaign.updatedAt).toLocaleString()}
+          </p>
+        </div>
+        <span
+          data-tone={badge.tone}
+          className="text-xs px-2 py-0.5 rounded bg-muted self-start"
+        >
+          {badge.label}
+        </span>
+      </header>
+
+      <section className="mb-6">
+        <h2 className="text-sm font-medium mb-2">Send progress</h2>
+        <p className="text-2xl font-semibold tabular-nums">
+          {formatCampaignProgress({
+            totalRecipients: campaign.totalRecipients,
+            sentCount: campaign.sentCount,
+          })}
+        </p>
+      </section>
+
+      <section className="mb-6 grid grid-cols-2 sm:grid-cols-3 gap-4">
+        <Stat label="Opens" value={campaign.openCount} />
+        <Stat label="Clicks" value={campaign.clickCount} />
+        <Stat label="Replies" value={campaign.replyCount} />
+        <Stat label="Bounces" value={campaign.bounceCount} />
+        <Stat label="Unsubscribes" value={campaign.unsubscribeCount} />
+        <Stat label="Total recipients" value={campaign.totalRecipients} />
+      </section>
+
+      {campaign.queueStats && (
+        <section className="mb-6">
+          <h2 className="text-sm font-medium mb-2">Queue</h2>
+          <div className="grid grid-cols-2 sm:grid-cols-4 gap-4">
+            <Stat label="Pending" value={campaign.queueStats.pending ?? 0} />
+            <Stat label="Sent" value={campaign.queueStats.sent ?? 0} />
+            <Stat label="Failed" value={campaign.queueStats.failed ?? 0} />
+            <Stat label="Bounced" value={campaign.queueStats.bounced ?? 0} />
+          </div>
+        </section>
+      )}
+
+      <footer className="pt-4 border-t flex items-center gap-3">
+        <Button
+          type="button"
+          variant="outline"
+          onClick={onDelete}
+          disabled={deleting}
+        >
+          {deleting ? 'Deleting…' : 'Delete campaign'}
+        </Button>
+      </footer>
+    </>
+  )
+}
+
+function Stat({ label, value }: { label: string; value: number }) {
+  return (
+    <div className="rounded border p-3">
+      <div className="text-xs text-muted-foreground">{label}</div>
+      <div className="text-xl font-semibold tabular-nums">{value}</div>
+    </div>
+  )
+}

--- a/src/app/(frontend)/dashboard/campaigns/new/page.tsx
+++ b/src/app/(frontend)/dashboard/campaigns/new/page.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import { Suspense, useCallback, useEffect, useMemo, useState } from 'react'
-import { useSearchParams } from 'next/navigation'
+import { useRouter, useSearchParams } from 'next/navigation'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
@@ -34,6 +34,7 @@ type SubmitResult =
   | { kind: 'error'; message: string }
 
 function NewCampaignPageInner() {
+  const router = useRouter()
   const searchParams = useSearchParams()
   const [name, setName] = useState('')
   const [subject, setSubject] = useState('')
@@ -114,11 +115,15 @@ function NewCampaignPageInner() {
       if (!res.ok || !data?.success) {
         throw new Error(data?.error || `Request failed (${res.status})`)
       }
+      const campaignId = data.campaign?.id ?? ''
       setSubmit({
         kind: 'success',
-        campaignId: data.campaign?.id ?? '',
+        campaignId,
         queued: data.queuedEmails ?? parsed.recipients.length,
       })
+      if (campaignId) {
+        router.push(`/dashboard/campaigns/${campaignId}`)
+      }
     } catch (err) {
       setSubmit({
         kind: 'error',

--- a/src/app/(frontend)/dashboard/campaigns/page.tsx
+++ b/src/app/(frontend)/dashboard/campaigns/page.tsx
@@ -1,0 +1,143 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+import Link from 'next/link'
+import { Button } from '@/components/ui/button'
+import {
+  describeCampaignStatus,
+  formatCampaignProgress,
+} from '@/lib/campaignStatus'
+
+type CampaignSummary = {
+  id: string
+  name: string
+  status: string
+  totalRecipients: number
+  sentCount: number
+  openCount: number
+  clickCount: number
+  replyCount: number
+  bounceCount: number
+  unsubscribeCount: number
+  createdAt: string
+  updatedAt: string
+}
+
+type LoadState =
+  | { kind: 'loading' }
+  | { kind: 'ready'; campaigns: CampaignSummary[] }
+  | { kind: 'error'; message: string }
+
+export default function CampaignsListPage() {
+  const [state, setState] = useState<LoadState>({ kind: 'loading' })
+
+  useEffect(() => {
+    let cancelled = false
+    fetch('/api/campaigns')
+      .then(async (res) => {
+        const data = await res.json().catch(() => ({}))
+        if (!res.ok || !data?.success) {
+          throw new Error(data?.error || `Failed (${res.status})`)
+        }
+        return data.campaigns as CampaignSummary[]
+      })
+      .then((campaigns) => {
+        if (!cancelled) setState({ kind: 'ready', campaigns })
+      })
+      .catch((err) => {
+        if (cancelled) return
+        setState({
+          kind: 'error',
+          message: err instanceof Error ? err.message : String(err),
+        })
+      })
+    return () => {
+      cancelled = true
+    }
+  }, [])
+
+  return (
+    <div className="p-8">
+      <div className="max-w-4xl mx-auto">
+        <header className="mb-6 flex items-center justify-between gap-4">
+          <h1 className="text-2xl font-bold">Campaigns</h1>
+          <Link href="/dashboard/campaigns/new">
+            <Button>New campaign</Button>
+          </Link>
+        </header>
+
+        {state.kind === 'loading' && (
+          <p className="text-sm text-muted-foreground">Loading campaigns…</p>
+        )}
+
+        {state.kind === 'error' && (
+          <p className="text-sm text-red-600">
+            Couldn&apos;t load campaigns: {state.message}
+          </p>
+        )}
+
+        {state.kind === 'ready' && state.campaigns.length === 0 && (
+          <div className="rounded border bg-muted/30 p-8 text-center">
+            <p className="text-sm text-muted-foreground mb-3">
+              You haven&apos;t created any campaigns yet.
+            </p>
+            <Link href="/dashboard/campaigns/new">
+              <Button>Create your first campaign</Button>
+            </Link>
+          </div>
+        )}
+
+        {state.kind === 'ready' && state.campaigns.length > 0 && (
+          <div className="rounded border overflow-hidden">
+            <table className="w-full text-sm">
+              <thead className="bg-muted/50 text-left">
+                <tr>
+                  <th className="px-4 py-2 font-medium">Name</th>
+                  <th className="px-4 py-2 font-medium">Status</th>
+                  <th className="px-4 py-2 font-medium">Sent</th>
+                  <th className="px-4 py-2 font-medium">Replies</th>
+                  <th className="px-4 py-2 font-medium">Created</th>
+                </tr>
+              </thead>
+              <tbody>
+                {state.campaigns.map((c) => {
+                  const badge = describeCampaignStatus(c.status)
+                  return (
+                    <tr key={c.id} className="border-t hover:bg-muted/20">
+                      <td className="px-4 py-2">
+                        <Link
+                          href={`/dashboard/campaigns/${c.id}`}
+                          className="underline"
+                        >
+                          {c.name}
+                        </Link>
+                      </td>
+                      <td className="px-4 py-2">
+                        <span
+                          data-tone={badge.tone}
+                          className="text-xs px-2 py-0.5 rounded bg-muted"
+                        >
+                          {badge.label}
+                        </span>
+                      </td>
+                      <td className="px-4 py-2 tabular-nums">
+                        {formatCampaignProgress({
+                          totalRecipients: c.totalRecipients,
+                          sentCount: c.sentCount,
+                        })}
+                      </td>
+                      <td className="px-4 py-2 tabular-nums">{c.replyCount}</td>
+                      <td className="px-4 py-2 text-muted-foreground">
+                        {new Date(c.createdAt).toLocaleDateString()}
+                      </td>
+                    </tr>
+                  )
+                })}
+              </tbody>
+            </table>
+          </div>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/src/lib/campaignStatus.ts
+++ b/src/lib/campaignStatus.ts
@@ -1,0 +1,49 @@
+export type CampaignStatus =
+  | 'draft'
+  | 'scheduled'
+  | 'sending'
+  | 'completed'
+  | 'paused'
+
+export type CampaignStatusBadge = {
+  label: string
+  tone: 'neutral' | 'info' | 'progress' | 'success' | 'warning'
+}
+
+const KNOWN: Record<CampaignStatus, CampaignStatusBadge> = {
+  draft: { label: 'Draft', tone: 'neutral' },
+  scheduled: { label: 'Scheduled', tone: 'info' },
+  sending: { label: 'Sending', tone: 'progress' },
+  completed: { label: 'Completed', tone: 'success' },
+  paused: { label: 'Paused', tone: 'warning' },
+}
+
+export function describeCampaignStatus(
+  status: string | null | undefined,
+): CampaignStatusBadge {
+  if (status && status in KNOWN) {
+    return KNOWN[status as CampaignStatus]
+  }
+  return { label: status ? capitalize(status) : 'Unknown', tone: 'neutral' }
+}
+
+export function formatCampaignProgress(input: {
+  totalRecipients: number
+  sentCount: number
+}): string {
+  const total = Math.max(0, input.totalRecipients)
+  const sent = clamp(input.sentCount, 0, total)
+  if (total === 0) return '0 / 0'
+  const pct = Math.round((sent / total) * 100)
+  return `${sent} / ${total} (${pct}%)`
+}
+
+function clamp(value: number, min: number, max: number): number {
+  if (Number.isNaN(value)) return min
+  return Math.min(max, Math.max(min, value))
+}
+
+function capitalize(s: string): string {
+  if (!s) return s
+  return s[0].toUpperCase() + s.slice(1)
+}

--- a/tests/int/campaignStatus.int.spec.ts
+++ b/tests/int/campaignStatus.int.spec.ts
@@ -1,0 +1,89 @@
+import { describe, expect, it } from 'vitest'
+import {
+  describeCampaignStatus,
+  formatCampaignProgress,
+} from '@/lib/campaignStatus'
+
+describe('describeCampaignStatus', () => {
+  it.each([
+    ['draft', { label: 'Draft', tone: 'neutral' }],
+    ['scheduled', { label: 'Scheduled', tone: 'info' }],
+    ['sending', { label: 'Sending', tone: 'progress' }],
+    ['completed', { label: 'Completed', tone: 'success' }],
+    ['paused', { label: 'Paused', tone: 'warning' }],
+  ] as const)('maps known %s status', (input, expected) => {
+    expect(describeCampaignStatus(input)).toEqual(expected)
+  })
+
+  it('falls back to capitalized neutral for unknown status', () => {
+    expect(describeCampaignStatus('archived')).toEqual({
+      label: 'Archived',
+      tone: 'neutral',
+    })
+  })
+
+  it('handles null and undefined', () => {
+    expect(describeCampaignStatus(null)).toEqual({
+      label: 'Unknown',
+      tone: 'neutral',
+    })
+    expect(describeCampaignStatus(undefined)).toEqual({
+      label: 'Unknown',
+      tone: 'neutral',
+    })
+  })
+
+  it('handles empty string as Unknown', () => {
+    expect(describeCampaignStatus('')).toEqual({
+      label: 'Unknown',
+      tone: 'neutral',
+    })
+  })
+})
+
+describe('formatCampaignProgress', () => {
+  it('formats with percentage', () => {
+    expect(
+      formatCampaignProgress({ totalRecipients: 100, sentCount: 25 }),
+    ).toBe('25 / 100 (25%)')
+  })
+
+  it('returns 0 / 0 when total is zero', () => {
+    expect(
+      formatCampaignProgress({ totalRecipients: 0, sentCount: 0 }),
+    ).toBe('0 / 0')
+  })
+
+  it('clamps sent above total back to total (no >100% display)', () => {
+    expect(
+      formatCampaignProgress({ totalRecipients: 10, sentCount: 25 }),
+    ).toBe('10 / 10 (100%)')
+  })
+
+  it('clamps negative sent count to zero', () => {
+    expect(
+      formatCampaignProgress({ totalRecipients: 10, sentCount: -3 }),
+    ).toBe('0 / 10 (0%)')
+  })
+
+  it('treats negative total as zero', () => {
+    expect(
+      formatCampaignProgress({ totalRecipients: -5, sentCount: 1 }),
+    ).toBe('0 / 0')
+  })
+
+  it('rounds percentage to nearest integer', () => {
+    expect(
+      formatCampaignProgress({ totalRecipients: 3, sentCount: 1 }),
+    ).toBe('1 / 3 (33%)')
+    expect(
+      formatCampaignProgress({ totalRecipients: 3, sentCount: 2 }),
+    ).toBe('2 / 3 (67%)')
+  })
+
+  it('handles NaN sent count as zero', () => {
+    expect(
+      formatCampaignProgress({ totalRecipients: 10, sentCount: NaN }),
+    ).toBe('0 / 10 (0%)')
+  })
+})


### PR DESCRIPTION
A user could create a campaign but had no way to see it afterward —
no listing, no detail view, no status, no sent/open/click counts. The
GET /api/campaigns and GET /api/campaigns/:id endpoints already
existed; only the UI was missing.

- /dashboard/campaigns: lists campaigns with status badge, sent
  progress, reply count, created date. Empty-state CTA links to
  /dashboard/campaigns/new.
- /dashboard/campaigns/[id]: shows status, send progress, opens /
  clicks / replies / bounces / unsubscribes / total recipients, plus
  optional queue stats (pending / sent / failed / bounced) when the
  API returns them. Includes a delete action with confirm prompt.
- /dashboard/campaigns/new: on successful POST, router.push to the
  new campaign's detail page so the user lands somewhere meaningful.
- src/lib/campaignStatus.ts: pure helpers (status badge label/tone,
  sent progress formatter with clamp + percent rounding) so render
  logic is unit-testable without mounting React.

15 vitest specs in tests/int/campaignStatus.int.spec.ts cover all
known + unknown statuses, null/undefined/empty inputs, and the
formatter's clamp / NaN / zero-total / rounding paths.

No API route, schema, migration, or send-pipeline changes. tsc clean
(error count went from 10 pre-existing on main to 0 — earlier merged
PRs cleared them). Full test:int matches main baseline (only
api.int.spec.ts still fails on missing PAYLOAD_SECRET, pre-existing).

Co-Authored-By: Paperclip <noreply@paperclip.ing>

🤖 Generated with [Claude Code](https://claude.com/claude-code)