### PR TITLE
hir-130: add GitHub Actions CI (typecheck + lint + test:int)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,66 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+jobs:
+  checks:
+    name: typecheck · lint · test:int
+    runs-on: ubuntu-latest
+
+    services:
+      postgres:
+        image: postgres:16-alpine
+        env:
+          POSTGRES_USER: coldflow
+          POSTGRES_PASSWORD: coldflow
+          POSTGRES_DB: coldflow
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U coldflow -d coldflow"
+          --health-interval 5s
+          --health-timeout 3s
+          --health-retries 10
+
+    env:
+      # Matches docker-compose.yaml + .env.example for the payload DB.
+      DATABASE_URL: postgres://coldflow:coldflow@localhost:5432/coldflow
+      DATABASE_URL_PAYLOAD: postgres://coldflow:coldflow@localhost:5432/payload
+      # Test-only secret. Payload refuses to boot without one.
+      PAYLOAD_SECRET: ci-test-secret
+      NEXT_PUBLIC_SERVER_URL: http://localhost:3000
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 10
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          # Matches the Node version pinned in Dockerfile.
+          node-version: 22.17.0
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Create payload database
+        run: |
+          PGPASSWORD=coldflow psql -h localhost -U coldflow -d coldflow \
+            -c "CREATE DATABASE payload;"
+
+      - name: Typecheck
+        run: pnpm exec tsc --noEmit
+
+      - name: Lint
+        run: pnpm lint
+
+      - name: Integration tests
+        run: pnpm test:int

--- a/README.md
+++ b/README.md
@@ -18,6 +18,21 @@
 - `pnpm dev`
 - navigate to `localhost:3000`
 
+# CI
+
+Every pull request and every push to `main` runs `.github/workflows/ci.yml`,
+which fails the build if any of the following fail:
+
+- `pnpm install --frozen-lockfile`
+- `pnpm exec tsc --noEmit` (typecheck — there is no `typecheck` script yet)
+- `pnpm lint`
+- `pnpm test:int`
+
+`test:int` boots Payload, so CI provisions a Postgres 16 service container and
+sets `DATABASE_URL_PAYLOAD` + `PAYLOAD_SECRET` for the run. To reproduce the CI
+job locally, mirror the env from the workflow and `docker compose up -d db`
+before running the same commands.
+
 
 # MVP features:
 


### PR DESCRIPTION
## Summary

Adds `.github/workflows/ci.yml` so PRs to `pypesdev/coldflow` actually get tested before merge. Today the open HIR-94 PRs all show "no checks reported" — `pnpm test:int` only runs on the engineer's local machine.

The workflow runs on every `pull_request` and every push to `main`:

- `pnpm install --frozen-lockfile`
- `pnpm exec tsc --noEmit` — there is no `typecheck` script in `package.json` yet, so the issue's `tsc --noEmit` fallback is used directly
- `pnpm lint`
- `pnpm test:int`

`test:int` boots Payload, which refuses to start without `PAYLOAD_SECRET` and a Postgres connection. CI provisions a `postgres:16-alpine` service container (matches `docker-compose.yaml`), creates the `payload` database, and exports `DATABASE_URL_PAYLOAD` + a test-only `PAYLOAD_SECRET`. Node and pnpm versions match the Dockerfile: Node 22.17.0, pnpm 10 (no `packageManager` field is pinned in `package.json`, so the workflow pins explicitly).

README has a new `# CI` section documenting the four commands so contributors know what to expect locally.

Once merged, all open HIR-94 PRs will start getting checks after a rebase. Per HIR-130: Vercel preview-deploy auth, E2E tests, and coverage gates are out of scope.

## Test plan

- [x] `pnpm install --frozen-lockfile` succeeds locally with pnpm 10.23.0
- [x] `pnpm exec tsc --noEmit` passes on `origin/main`
- [x] `pnpm lint` passes (warnings only) on `origin/main`
- [x] 7/8 `test:int` files pass without env; the 8th (`api.int.spec.ts`) needs Payload + Postgres, which CI now provides
- [ ] CI green on this PR after open
- [ ] After merge, rebase one open HIR-94 PR and confirm CI runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)