### PR TITLE
fix: provide 32-char dev defaults in .env.example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,16 +1,19 @@
+# Dev-only defaults — fine for local. Rotate before deploying anywhere real.
+
 # Used to encrypt JWT tokens
-PAYLOAD_SECRET=YOUR_SECRET_HERE
+PAYLOAD_SECRET=dev_payload_secret_change_me_32_chars_min
 
 # Used to configure CORS, format links and more. No trailing slash
 NEXT_PUBLIC_SERVER_URL=http://localhost:3000
 
 # Secret used to authenticate cron jobs
-CRON_SECRET=YOUR_CRON_SECRET_HERE
+CRON_SECRET=dev_cron_secret_change_me_32_chars_minimum
 
 # Used to validate preview requests
-PREVIEW_SECRET=YOUR_SECRET_HERE
+PREVIEW_SECRET=dev_preview_secret_change_me_32_chars_min
 
-BETTER_AUTH_SECRET=YOUR_SECRET_HERE
+# Required by BetterAuth — must be at least 32 chars
+BETTER_AUTH_SECRET=dev_better_auth_secret_change_me_32_chars
 
 BETTER_AUTH_URL=http://localhost:3000
 


### PR DESCRIPTION
## Summary
- `cp .env.example .env && pnpm dev` was failing with `BetterAuthError: Invalid BETTER_AUTH_SECRET: must be at least 32 characters long`.
- Replaces the 16-char `YOUR_SECRET_HERE` placeholders with working dev-only defaults that satisfy BetterAuth's length requirement, so onboarding is clone → cp → run.
- Header comment marks them as dev-only and to rotate before real deploys.

## Test plan
- [ ] `cp .env.example .env`
- [ ] `pnpm i && docker compose up -d db && pnpm dev`
- [ ] App boots without the BetterAuth length error