### PR TITLE
hir-111: CHANGELOG.md + v0.1.0 baseline

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,47 @@
+# Changelog
+
+All notable changes to Coldflow are documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.1.0] - 2026-05-16
+
+First tagged baseline. Establishes a stable target for external contributors.
+
+### Added
+
+- **DMARC validation.** Enter a domain and see SPF / DKIM / DMARC records inline.
+  Also shipped as a standalone CLI: [`npx dmarc-doctor`](https://github.com/pypesdev/dmarc-doctor).
+- **Google SMTP integration.** Connect a Gmail account via OAuth and send through
+  the connected account. Companion CLI for self-hosted SMTP transport
+  diagnostics: [`npx smtp-warmer`](https://github.com/pypesdev/smtp-warmer).
+- **CSV contact upload.** Import recipient lists from CSV with per-recipient
+  variable substitution (`{first_name}`, etc.).
+- **Single-step sequences.** Create a one-step campaign with basic
+  personalization and a strict per-account sending limit.
+- **Silent-reply automation.** Schedule a single follow-up when a prospect
+  replies once and then goes quiet. Auto-cancels if they reply again before
+  the follow-up sends.
+- **Templates library.** Curated 10-template starter pack across sales,
+  recruiting, partnership, warm-intro, and follow-up categories, each with
+  YAML front-matter (subject, persona, use case, deliverability notes) and a
+  plaintext body under 120 words. See [`templates/`](templates/) and
+  [pypesdev/coldflow#11](https://github.com/pypesdev/coldflow/pull/11).
+- **Campaigns list + detail pages.** Dashboard views for browsing existing
+  campaigns and inspecting per-campaign state ([#19](https://github.com/pypesdev/coldflow/pull/19)).
+- **GitHub Actions CI.** Every PR runs `tsc --noEmit`, `pnpm lint`, and
+  `pnpm test:int` against a Postgres 16 service container
+  ([#23](https://github.com/pypesdev/coldflow/pull/23)).
+
+### Fixed
+
+- **MIME RFC encoding.** Header B-encoding (RFC 2047) and quoted-printable
+  body encoding (RFC 2045) so non-ASCII characters — em dashes, smart quotes,
+  accents — render correctly across stricter MTAs instead of as mojibake
+  ([#10](https://github.com/pypesdev/coldflow/pull/10)).
+
+[Unreleased]: https://github.com/pypesdev/coldflow/compare/v0.1.0...HEAD
+[0.1.0]: https://github.com/pypesdev/coldflow/releases/tag/v0.1.0

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "coldflow",
-  "version": "1.0.0",
+  "version": "0.1.0",
   "description": "Open Source Cold Email Outreach Tool",
   "type": "module",
   "scripts": {


### PR DESCRIPTION
## Goal

Establish a stable versioning baseline for `pypesdev/coldflow` so external contributors have a target ([HIR-111], part of the OSS increments plan in HIR-105).

## Changes

1. **New `CHANGELOG.md`** at repo root in [Keep a Changelog 1.1.0](https://keepachangelog.com/en/1.1.0/) format with a `[0.1.0] - 2026-05-16` section listing shipped MVP features: DMARC validation, Google SMTP integration, CSV contact upload, single-step sequences, silent-reply automation, templates library.
2. **Bump `package.json`** from `1.0.0` to `0.1.0` — the prior `1.0.0` was placeholder; v0.1.0 is the real first tagged baseline per the SemVer 0.x convention for pre-stable APIs.
3. Templates library entry links to the merged PR #11.

## After merge

- Tag `v0.1.0` on the merge commit and `git push origin v0.1.0`
- Create GitHub release at `releases/tag/v0.1.0` referencing the CHANGELOG section

(These follow the merge — they need to point at the `main` commit, not the PR branch.)

## Done when

- [ ] CHANGELOG.md merged on `main`
- [ ] `git tag --list v0.1.0` shows the tag locally and on `origin`
- [ ] GitHub release page exists at `releases/tag/v0.1.0`

🤖 Generated with [Claude Code](https://claude.com/claude-code)